### PR TITLE
Point front-end survey links at the deployed Render URL

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,4 @@
+# Production build: point the front end's "Survey Tool" links at the deployed
+# FastAPI survey app. Override anywhere (e.g. a Vercel env var) by setting
+# VITE_SURVEY_URL; a real environment variable takes precedence over this file.
+VITE_SURVEY_URL=https://sunshine-zzrc.onrender.com


### PR DESCRIPTION
## Summary

The front end's header ("Survey Tool →") and footer ("Open the survey tool") links were defaulting to `/`, which on the deployed front end (`sunshine-pearl.vercel.app`) just looped back to the front end itself. This points them at the live FastAPI survey tool.

- Adds `frontend/.env.production` setting `VITE_SURVEY_URL=https://sunshine-zzrc.onrender.com`, so a production `vite build` bakes the deployed survey-tool URL into both links.
- Still overridable by a real `VITE_SURVEY_URL` environment variable (e.g. set in Vercel), which takes precedence over the file.

## Testing

- `npm run build` in `frontend/` succeeds and the Render URL is present in the production bundle (both links resolve to it).

Once merged, Vercel auto-deploys `master` and the two links will open the survey tool instead of the front end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMQ2LNzm9UvwVaBwrDXL4U)_