### PR TITLE
Browser login screen for the admin UI + auto-detect base URL on Render

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,13 @@ SMTP_FROM=Sunshine Surveys <no-reply@sunshine.local>
 # Use STARTTLS (true, typical for port 587) or implicit SSL (false, port 465).
 SMTP_USE_TLS=true
 
-# --- Admin authentication (HTTP Basic) ---
-# Auth is enforced on the researcher/admin UI only when ADMIN_PASSWORD is set.
-# Leave it empty to keep the admin UI open for local development. Respondent
-# survey links (/survey/<token>) are always public.
+# --- Admin authentication (browser login screen) ---
+# A login screen at /login (backed by a signed session cookie) is enforced on
+# the researcher/admin UI only when ADMIN_PASSWORD is set. Leave it empty to
+# keep the admin UI open for local development. Respondent survey links
+# (/survey/<token>) are always public.
 ADMIN_USER=admin
 ADMIN_PASSWORD=
+# Optional. Signs the session cookie; defaults to a value derived from
+# ADMIN_PASSWORD. Set to a long random string to pin it explicitly.
+SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # Copy to .env and adjust. All values are optional; sensible defaults are used.
 
-# Where the app is reachable. Used to build survey links in invitation emails.
-BASE_URL=http://localhost:8000
+# Public URL used to build survey/invitation links. Leave empty to auto-detect:
+# on Render the platform's RENDER_EXTERNAL_URL is used automatically; otherwise
+# it defaults to http://localhost:8000. Set it explicitly to pin a custom domain.
+BASE_URL=
 
 # Database (SQLAlchemy URL). Defaults to a local SQLite file.
 DATABASE_URL=sqlite:///./sunshine.db

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ FastAPI app.
     price attribute.
   - **Market simulator** — define competing products and see predicted
     share-of-preference.
-- **Admin authentication** — the researcher UI is protected by HTTP Basic Auth
-  (enabled by setting `ADMIN_PASSWORD`). Respondent survey links stay public.
+- **Admin authentication** — the researcher UI is protected by a browser login
+  screen (session cookie), enabled by setting `ADMIN_PASSWORD`. Respondent
+  survey links stay public.
 
 ## Quick start
 
@@ -112,15 +113,18 @@ Works with Gmail, SendGrid, Mailgun, Amazon SES, etc. via standard SMTP.
 
 ## Admin authentication
 
-The researcher/admin UI uses HTTP Basic Auth, enforced **only when
-`ADMIN_PASSWORD` is set** (otherwise the admin UI is open, convenient for local
-development). Respondent survey links (`/survey/<token>`) and `/healthz` are
-always public.
+The researcher/admin UI is protected by a browser **login screen** at `/login`
+(backed by a signed session cookie), enforced **only when `ADMIN_PASSWORD` is
+set** (otherwise the admin UI is open, convenient for local development).
+Signed-out visitors to an admin page are redirected to `/login`; a **Log out**
+link appears in the header once signed in. Respondent survey links
+(`/survey/<token>`) and `/healthz` are always public.
 
 | Variable | Purpose |
 | --- | --- |
 | `ADMIN_USER` | Admin username (default `admin`). |
 | `ADMIN_PASSWORD` | Admin password. **Empty = auth disabled.** Set it to require login. |
+| `SECRET_KEY` | Optional. Signs the session cookie; defaults to a value derived from `ADMIN_PASSWORD`. |
 
 ## The methodology, briefly
 
@@ -155,7 +159,7 @@ and PME (too expensive × cheap).
 app/
   main.py            FastAPI app + routes wiring + auth gating
   config.py          Settings (env / .env)
-  auth.py            HTTP Basic Auth dependency for the admin UI
+  auth.py            login screen + session-cookie guard for the admin UI
   database.py        SQLAlchemy engine & session
   models.py          ORM: Survey, Attribute, Level, Task, Concept, Participant,
                      Response, PricePerception

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,38 +1,103 @@
-"""Admin authentication via HTTP Basic Auth.
+"""Admin authentication via a browser login form + signed session cookie.
 
 Enforced only when ``ADMIN_PASSWORD`` is configured. When it is empty the
-dependency is a no-op so the admin UI is reachable during local development.
-Respondent survey routes never use this dependency and stay public.
+``require_admin`` dependency is a no-op so the admin UI is reachable during
+local development. Respondent survey routes never use this dependency and stay
+public.
 """
 
 from __future__ import annotations
 
+import hashlib
 import secrets
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import RedirectResponse
 
 from .config import settings
+from .templating import templates
 
-_basic = HTTPBasic(auto_error=False)
+
+class NotAuthenticated(Exception):
+    """Raised by ``require_admin`` when a signed-in admin session is missing.
+
+    A handler registered in ``app.main`` turns this into a redirect to the
+    login page.
+    """
 
 
-def require_admin(
-    credentials: HTTPBasicCredentials | None = Depends(_basic),
-) -> None:
+def session_secret() -> str:
+    """Stable secret for signing the session cookie.
+
+    Prefers an explicit ``SECRET_KEY``; otherwise derives a stable value from
+    the admin password so sessions survive restarts without extra config.
+    Falls back to a fixed development value when auth is disabled (the cookie
+    is meaningless then anyway).
+    """
+    if settings.secret_key:
+        return settings.secret_key
+    if settings.admin_password:
+        return hashlib.sha256(
+            f"sunshine-session:{settings.admin_password}".encode()
+        ).hexdigest()
+    return "sunshine-dev-insecure-secret"
+
+
+def credentials_valid(username: str, password: str) -> bool:
+    """Constant-time check of submitted credentials against the configured admin."""
+    user_ok = secrets.compare_digest(username, settings.admin_user)
+    pass_ok = secrets.compare_digest(password, settings.admin_password)
+    return bool(settings.admin_password) and user_ok and pass_ok
+
+
+def require_admin(request: Request) -> None:
+    """Guard admin routes; raises ``NotAuthenticated`` when signed out."""
     if not settings.auth_enabled:
         return  # auth disabled (no password configured)
+    if request.session.get("admin"):
+        return
+    raise NotAuthenticated()
 
-    unauthorized = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Not authenticated",
-        headers={"WWW-Authenticate": "Basic"},
+
+def _safe_next(target: str | None) -> str:
+    """Only allow same-site relative redirects to avoid open-redirect abuse."""
+    if not target or not target.startswith("/") or target.startswith("//"):
+        return "/"
+    return target
+
+
+router = APIRouter()
+
+
+@router.get("/login")
+def login_form(request: Request, next: str = "/"):
+    nxt = _safe_next(next)
+    # Nothing to log in to when auth is off, or already signed in.
+    if not settings.auth_enabled or request.session.get("admin"):
+        return RedirectResponse(nxt, status_code=303)
+    return templates.TemplateResponse(request, "login.html", {"next": nxt})
+
+
+@router.post("/login")
+def login_submit(
+    request: Request,
+    username: str = Form(""),
+    password: str = Form(""),
+    next: str = Form("/"),
+):
+    nxt = _safe_next(next)
+    if credentials_valid(username, password):
+        request.session["admin"] = True
+        return RedirectResponse(nxt, status_code=303)
+    return templates.TemplateResponse(
+        request,
+        "login.html",
+        {"next": nxt, "error": "Incorrect username or password."},
+        status_code=401,
     )
-    if credentials is None:
-        raise unauthorized
 
-    # Constant-time comparison to avoid leaking length/contents via timing.
-    user_ok = secrets.compare_digest(credentials.username, settings.admin_user)
-    pass_ok = secrets.compare_digest(credentials.password, settings.admin_password)
-    if not (user_ok and pass_ok):
-        raise unauthorized
+
+@router.get("/logout")
+def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse("/login", status_code=303)

--- a/app/config.py
+++ b/app/config.py
@@ -10,9 +10,15 @@ class Settings(BaseSettings):
         env_file=".env", env_file_encoding="utf-8", extra="ignore"
     )
 
-    # General
-    base_url: str = "http://localhost:8000"
+    # General. base_url is the public URL used to build survey/invitation
+    # links. Leave it empty to auto-detect from the platform (see
+    # effective_base_url); set it explicitly to pin a custom domain.
+    base_url: str = ""
     database_url: str = "sqlite:///./sunshine.db"
+
+    # Set automatically by Render to the service's public URL. Used as a
+    # fallback for base_url so links are correct without manual configuration.
+    render_external_url: str = ""
 
     # Email / SMTP. When smtp_host is empty the app runs in "console" mode:
     # invitations are logged and written to dev_outbox/ instead of being sent.
@@ -32,6 +38,18 @@ class Settings(BaseSettings):
     # Secret used to sign the admin session cookie. Optional: when empty a
     # stable secret is derived from admin_password (see auth.session_secret).
     secret_key: str = ""
+
+    @property
+    def effective_base_url(self) -> str:
+        """Public base URL for building links (no trailing slash).
+
+        Prefers an explicit ``BASE_URL``; otherwise falls back to the
+        platform-provided ``RENDER_EXTERNAL_URL`` (set automatically on Render)
+        so invitation/survey links use the right host without manual config;
+        finally defaults to localhost for local development.
+        """
+        url = self.base_url or self.render_external_url or "http://localhost:8000"
+        return url.rstrip("/")
 
     @property
     def email_enabled(self) -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -23,11 +23,15 @@ class Settings(BaseSettings):
     smtp_from: str = "Sunshine Surveys <no-reply@sunshine.local>"
     smtp_use_tls: bool = True
 
-    # Admin (researcher) HTTP Basic Auth. Enforcement is enabled only when
-    # admin_password is non-empty; otherwise the admin UI is open (handy for
-    # local development). Respondent survey links are always public.
+    # Admin (researcher) login. Enforcement is enabled only when admin_password
+    # is non-empty; otherwise the admin UI is open (handy for local
+    # development). Respondent survey links are always public.
     admin_user: str = "admin"
     admin_password: str = ""
+
+    # Secret used to sign the admin session cookie. Optional: when empty a
+    # stable secret is derived from admin_password (see auth.session_secret).
+    secret_key: str = ""
 
     @property
     def email_enabled(self) -> bool:
@@ -36,7 +40,7 @@ class Settings(BaseSettings):
 
     @property
     def auth_enabled(self) -> bool:
-        """True when admin Basic Auth should be enforced."""
+        """True when admin login should be enforced."""
         return bool(self.admin_password)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import RedirectResponse
+from starlette.middleware.sessions import SessionMiddleware
 
-from .auth import require_admin
+from . import auth
+from .auth import NotAuthenticated, require_admin, session_secret
 from .config import settings
 from .database import init_db
 from .routes import admin, survey
@@ -35,12 +38,29 @@ app = FastAPI(
     title="Sunshine — Survey & Conjoint Tool", version="0.2.0", lifespan=lifespan
 )
 
+# Signed session cookie backs the admin login. The secret is derived from the
+# admin password by default (see auth.session_secret).
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=session_secret(),
+    session_cookie="sunshine_session",
+    max_age=60 * 60 * 8,  # 8 hours
+    same_site="lax",
+)
+
+
+@app.exception_handler(NotAuthenticated)
+async def _login_redirect(request: Request, exc: NotAuthenticated) -> RedirectResponse:
+    """Send signed-out visitors to the login page, preserving where they were headed."""
+    return RedirectResponse(url=f"/login?next={request.url.path}", status_code=303)
+
 
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
-# Respondent survey routes are public; admin routes require Basic Auth.
+# Login/logout and respondent survey routes are public; admin routes require login.
+app.include_router(auth.router)
 app.include_router(survey.router)
 app.include_router(admin.router, dependencies=[Depends(require_admin)])

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -223,7 +223,7 @@ def send_invitations(survey_id: int, db: Session = Depends(get_db)):
     for participant in survey.participants:
         if participant.status == ParticipantStatus.completed:
             continue
-        link = f"{settings.base_url}/survey/{participant.token}"
+        link = f"{settings.effective_base_url}/survey/{participant.token}"
         subject, html, text = invitation_email(survey.name, link)
         if send_email(participant.email, subject, html, text):
             participant.status = ParticipantStatus.invited

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,7 +37,7 @@
     .pill.active { background: #e3f4e1; color: #2e7d32; }
     .pill.closed { background: #fce4e4; color: #c62828; }
     label { display: block; font-weight: 600; margin: 10px 0 4px; }
-    input[type=text], input[type=email], input[type=number], textarea, select {
+    input[type=text], input[type=email], input[type=number], input[type=password], textarea, select {
       width: 100%; padding: 9px 11px; border: 1px solid var(--line);
       border-radius: 7px; font: inherit; background: #fff;
     }
@@ -65,8 +65,11 @@
 </head>
 <body>
   <header class="topbar">
-    <div class="wrap" style="padding:0; max-width:920px;">
+    <div class="wrap" style="padding:0; max-width:920px; display:flex; justify-content:space-between; align-items:center;">
       <a href="/">☀ Sunshine Surveys</a>
+      {% if request and request.session.get('admin') %}
+        <a href="/logout">Log out</a>
+      {% endif %}
     </div>
   </header>
   <div class="wrap">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Sign in · Sunshine{% endblock %}
+{% block content %}
+  <div class="card" style="max-width: 380px; margin: 7vh auto;">
+    <h1 style="margin-top: 0;">☀ Sign in</h1>
+    <p class="muted" style="margin-top: -8px;">Sunshine survey admin</p>
+
+    {% if error %}<p class="error">{{ error }}</p>{% endif %}
+
+    <form method="post" action="/login">
+      <input type="hidden" name="next" value="{{ next }}">
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username"
+             autocomplete="username" autofocus required>
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password"
+             autocomplete="current-password" required>
+      <button type="submit" style="margin-top: 18px; width: 100%;">Sign in</button>
+    </form>
+  </div>
+{% endblock %}

--- a/app/templating.py
+++ b/app/templating.py
@@ -11,4 +11,4 @@ from .config import settings
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
 
 templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
-templates.env.globals["base_url"] = settings.base_url
+templates.env.globals["base_url"] = settings.effective_base_url

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,4 @@
+# Production build: point the front end's "Survey Tool" links at the deployed
+# FastAPI survey app. Override anywhere (e.g. a Vercel env var) by setting
+# VITE_SURVEY_URL; a real environment variable takes precedence over this file.
+VITE_SURVEY_URL=https://sunshine-zzrc.onrender.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sqlalchemy>=2.0
 jinja2>=3.1
 python-multipart>=0.0.9
 pydantic-settings>=2.0
+itsdangerous>=2.1
 numpy>=1.26
 scipy>=1.11
 

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -119,7 +119,7 @@ def seed(num_participants: int = 60, seed: int = 7) -> None:
         db.commit()
 
         print(f"Seeded conjoint survey id={survey.id} with {num_participants} responses.")
-        print(f"  Results: {settings.base_url}/surveys/{survey.id}/results")
+        print(f"  Results: {settings.effective_base_url}/surveys/{survey.id}/results")
 
         # --- Van Westendorp demo -------------------------------------------
         vw = Survey(
@@ -152,7 +152,7 @@ def seed(num_participants: int = 60, seed: int = 7) -> None:
             )
         db.commit()
         print(f"Seeded Van Westendorp survey id={vw.id} with {num_participants} responses.")
-        print(f"  Results: {settings.base_url}/surveys/{vw.id}/results")
+        print(f"  Results: {settings.effective_base_url}/surveys/{vw.id}/results")
 
 
 if __name__ == "__main__":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -146,6 +146,23 @@ def test_admin_login_flow_when_password_set(monkeypatch):
     assert c.get("/survey/nope").status_code == 404  # not a redirect to login
 
 
+def test_effective_base_url_auto_detect():
+    from app.config import Settings
+
+    # Explicit BASE_URL wins (and a trailing slash is trimmed).
+    s = Settings(base_url="https://custom.example/",
+                 render_external_url="https://x.onrender.com")
+    assert s.effective_base_url == "https://custom.example"
+
+    # Falls back to RENDER_EXTERNAL_URL when BASE_URL is unset.
+    s = Settings(base_url="", render_external_url="https://sunshine-zzrc.onrender.com")
+    assert s.effective_base_url == "https://sunshine-zzrc.onrender.com"
+
+    # Localhost default when neither is configured.
+    s = Settings(base_url="", render_external_url="")
+    assert s.effective_base_url == "http://localhost:8000"
+
+
 def test_van_westendorp_full_flow():
     init_db()
     client.post("/surveys", data={

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,19 +111,39 @@ def test_invalid_token_shows_not_found():
     assert "Link not found" in resp.text
 
 
-def test_admin_auth_enforced_when_password_set(monkeypatch):
+def test_admin_login_flow_when_password_set(monkeypatch):
     init_db()
     monkeypatch.setattr(settings, "admin_user", "boss")
     monkeypatch.setattr(settings, "admin_password", "s3cret")
 
-    # Admin pages require credentials.
-    assert client.get("/").status_code == 401
-    assert client.get("/", auth=("boss", "wrong")).status_code == 401
-    assert client.get("/", auth=("boss", "s3cret")).status_code == 200
+    c = TestClient(app)  # isolated cookie jar
+
+    # Signed-out admin pages redirect to the login screen.
+    r = c.get("/", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"].startswith("/login")
+
+    # The login screen is public and renders a form.
+    login = c.get("/login")
+    assert login.status_code == 200
+    assert "Sign in" in login.text
+
+    # Wrong credentials are rejected.
+    assert c.post("/login", data={"username": "boss", "password": "no"}).status_code == 401
+
+    # Correct credentials establish a session; admin pages then load.
+    ok = c.post("/login", data={"username": "boss", "password": "s3cret"},
+                follow_redirects=False)
+    assert ok.status_code == 303
+    assert c.get("/").status_code == 200
+
+    # Logout clears the session and re-protects admin pages.
+    c.get("/logout")
+    assert c.get("/", follow_redirects=False).status_code == 303
 
     # Health check and respondent survey routes stay public.
-    assert client.get("/healthz").status_code == 200
-    assert client.get("/survey/nope").status_code == 404  # not 401
+    assert c.get("/healthz").status_code == 200
+    assert c.get("/survey/nope").status_code == 404  # not a redirect to login
 
 
 def test_van_westendorp_full_flow():


### PR DESCRIPTION
## Summary

Two related survey-tool improvements.

### 1. Browser login screen (replaces HTTP Basic Auth)
The admin UI previously triggered the native browser Basic Auth popup. This swaps it for an in-page login form backed by a signed session cookie (Starlette `SessionMiddleware`).

- New **`/login`** (GET form, POST validate) and **`/logout`** routes. `require_admin` now **redirects** signed-out visitors to `/login` (preserving the destination via `?next=`) instead of returning `401`. A **"Log out"** link appears in the header when signed in.
- Credentials checked in constant time; the cookie is signed with `SECRET_KEY` or a stable secret derived from `ADMIN_PASSWORD`. Auth is still enforced **only when `ADMIN_PASSWORD` is set**; respondent survey routes and `/healthz` stay public.
- Adds the `itsdangerous` dependency (required by `SessionMiddleware`), a styled login template, and updated docs.

### 2. Auto-detect base URL from `RENDER_EXTERNAL_URL`
Survey/invitation links are built from `BASE_URL`, which is easy to misconfigure — a wrong value produces links pointing at the wrong host (the "Not Found" we hit). `BASE_URL` is now optional:

- When unset, it falls back to the platform-provided **`RENDER_EXTERNAL_URL`** (set automatically on Render), so links use the correct host with no manual config. An explicit `BASE_URL` still wins (e.g. a custom domain). Trailing slashes are trimmed to avoid `//survey` links.
- New `Settings.effective_base_url`; the templating global, invitation-link builder, and `seed_demo` use it.

## Testing

- `pytest` → **30 passing** (added the form-login flow test and a `effective_base_url` precedence test).
- Smoke-tested the login flow against a live `uvicorn`: signed-out `/` → 303 to `/login`; wrong creds → 401; correct creds → session established and admin loads; logout re-protects; respondent route stays public (404, not a redirect).
- Verified `RENDER_EXTERNAL_URL` is picked up for `effective_base_url` when `BASE_URL` is empty.

## Deploy note

After this deploys on Render, **remove (or clear) the `BASE_URL` env var** on the service so the auto-detect uses `RENDER_EXTERNAL_URL` — that permanently fixes the participant-link host. Admin login continues to use the existing `ADMIN_USER`/`ADMIN_PASSWORD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMQ2LNzm9UvwVaBwrDXL4U)_