### PR TITLE
Add Ranking / Rating survey type (matrix + ranking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ FastAPI app.
 
 ## What it does
 
-- **Two survey types**
+- **Survey types**
   - **Choice-Based Conjoint** — define attributes (e.g. *Price*, *Brand*,
     *Size*) and levels, auto-generate a randomized choice design (configurable
     options per task, optional "None of these"), and present choice tasks.
   - **Van Westendorp** — respondents answer the four classic price questions;
     the tool computes the Optimal Price Point (OPP), Indifference Price (IPP),
     and the acceptable price range (PMC–PME), with a curve chart.
+  - **Ranking / Rating** — define a list of items respondents either **rate**
+    on a shared scale (the matrix grid, with optional endpoint labels) or
+    **rank** in order; results show mean, distribution, and top-choice share
+    per item.
 - **Invite participants by email** — each respondent gets a unique survey link.
   Works with any SMTP provider, or runs in a no-credentials *console mode* for
   local development.

--- a/app/models.py
+++ b/app/models.py
@@ -41,6 +41,12 @@ def _new_token() -> str:
 class SurveyType(str, enum.Enum):
     conjoint = "conjoint"              # Choice-Based Conjoint
     van_westendorp = "van_westendorp"  # Price Sensitivity Meter
+    rating = "rating"                  # Ranking / Rating (matrix)
+
+
+class RatingMode(str, enum.Enum):
+    rate = "rate"  # rate each item on a shared scale (matrix grid)
+    rank = "rank"  # order the items from best (1) to worst (N)
 
 
 class SurveyStatus(str, enum.Enum):
@@ -93,6 +99,16 @@ class Survey(Base):
         back_populates="survey",
         cascade="all, delete-orphan",
         order_by="Task.position",
+    )
+    items: Mapped[list["Item"]] = relationship(
+        back_populates="survey",
+        cascade="all, delete-orphan",
+        order_by="Item.position",
+    )
+    rating_config: Mapped["RatingConfig | None"] = relationship(
+        back_populates="survey",
+        cascade="all, delete-orphan",
+        uselist=False,
     )
     participants: Mapped[list["Participant"]] = relationship(
         back_populates="survey", cascade="all, delete-orphan"
@@ -188,6 +204,66 @@ class ConceptLevel(Base):
     level: Mapped[Level] = relationship()
 
 
+class RatingConfig(Base):
+    """Per-survey settings for a Ranking / Rating survey (kept off the surveys
+    table so the schema stays additive — new table only — for existing DBs)."""
+
+    __tablename__ = "rating_configs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    survey_id: Mapped[int] = mapped_column(
+        ForeignKey("surveys.id", ondelete="CASCADE"), unique=True
+    )
+    mode: Mapped[RatingMode] = mapped_column(
+        Enum(RatingMode), default=RatingMode.rate, nullable=False
+    )
+    scale_points: Mapped[int] = mapped_column(Integer, default=5)
+    min_label: Mapped[str] = mapped_column(String(80), default="")
+    max_label: Mapped[str] = mapped_column(String(80), default="")
+
+    survey: Mapped[Survey] = relationship(back_populates="rating_config")
+
+
+class Item(Base):
+    """A statement/option respondents rate or rank in a Ranking/Rating survey."""
+
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    survey_id: Mapped[int] = mapped_column(
+        ForeignKey("surveys.id", ondelete="CASCADE")
+    )
+    text: Mapped[str] = mapped_column(String(300), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, default=0)
+
+    survey: Mapped[Survey] = relationship(back_populates="items")
+    responses: Mapped[list["ItemResponse"]] = relationship(
+        back_populates="item", cascade="all, delete-orphan"
+    )
+
+
+class ItemResponse(Base):
+    """One respondent's rating (scale value) or rank for a single item."""
+
+    __tablename__ = "item_responses"
+    __table_args__ = (
+        UniqueConstraint(
+            "participant_id", "item_id", name="uq_item_response_participant_item"
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    participant_id: Mapped[int] = mapped_column(
+        ForeignKey("participants.id", ondelete="CASCADE")
+    )
+    item_id: Mapped[int] = mapped_column(ForeignKey("items.id", ondelete="CASCADE"))
+    value: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+    participant: Mapped["Participant"] = relationship(back_populates="item_responses")
+    item: Mapped[Item] = relationship(back_populates="responses")
+
+
 class Participant(Base):
     __tablename__ = "participants"
     __table_args__ = (
@@ -210,6 +286,9 @@ class Participant(Base):
 
     survey: Mapped[Survey] = relationship(back_populates="participants")
     responses: Mapped[list["Response"]] = relationship(
+        back_populates="participant", cascade="all, delete-orphan"
+    )
+    item_responses: Mapped[list["ItemResponse"]] = relationship(
         back_populates="participant", cascade="all, delete-orphan"
     )
     price_perception: Mapped["PricePerception | None"] = relationship(

--- a/app/rating.py
+++ b/app/rating.py
@@ -1,0 +1,91 @@
+"""Summaries for Ranking / Rating surveys.
+
+Two modes:
+
+- ``rate`` — each respondent rates every item on a shared 1..scale_points scale
+  (the "matrix" grid). Higher is better.
+- ``rank`` — each respondent orders the items, 1 (best) .. N (worst). Lower is
+  better.
+
+For each item we report the response count, mean, the distribution across the
+columns, and a "top choice" share (top-box for rate; ranked #1 for rank). Items
+are returned sorted best-first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import RatingMode
+
+
+@dataclass
+class ItemSummary:
+    item_id: int
+    text: str
+    n: int
+    mean: float
+    distribution: list[int]  # counts aligned to columns, left -> right
+    top_choice_pct: float    # % of respondents giving this item the best response
+
+
+@dataclass
+class RatingSummary:
+    mode: RatingMode
+    columns: list[str]        # column headers (scale points, or rank positions)
+    num_responses: int        # respondents with at least one answer
+    items: list[ItemSummary]  # sorted best-first
+    min_label: str
+    max_label: str
+
+
+def summarize(
+    items: list[tuple[int, str]],
+    responses: list[dict[int, int]],
+    mode: RatingMode,
+    scale_points: int,
+    min_label: str = "",
+    max_label: str = "",
+) -> RatingSummary:
+    """Aggregate per-item statistics.
+
+    ``items`` is ordered ``[(item_id, text), ...]``. ``responses`` is one dict
+    per respondent mapping ``item_id -> value`` (rate: 1..scale_points; rank:
+    1..N where 1 is best). Raises ``ValueError`` when there are no responses.
+    """
+    non_empty = [r for r in responses if r]
+    if not non_empty:
+        raise ValueError("No responses yet.")
+
+    if mode == RatingMode.rank:
+        n_cols = len(items)
+        best_value = 1            # rank 1 is best
+        sort_descending = False   # lower mean rank first
+    else:
+        n_cols = max(2, scale_points)
+        best_value = n_cols       # top box is best
+        sort_descending = True    # higher mean first
+
+    columns = [str(i + 1) for i in range(n_cols)]
+
+    summaries: list[ItemSummary] = []
+    for item_id, text in items:
+        values = [r[item_id] for r in non_empty if item_id in r]
+        n = len(values)
+        dist = [0] * n_cols
+        for v in values:
+            if 1 <= v <= n_cols:
+                dist[v - 1] += 1
+        mean = (sum(values) / n) if n else 0.0
+        top = (100.0 * sum(1 for v in values if v == best_value) / n) if n else 0.0
+        summaries.append(ItemSummary(item_id, text, n, mean, dist, top))
+
+    summaries.sort(key=lambda s: s.mean, reverse=sort_descending)
+    return RatingSummary(
+        mode=mode,
+        columns=columns,
+        num_responses=len(non_empty),
+        items=summaries,
+        min_label=min_label,
+        max_label=max_label,
+    )

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -16,9 +16,12 @@ from ..database import get_db
 from ..email_utils import invitation_email, send_email
 from ..models import (
     Attribute,
+    Item,
     Level,
     Participant,
     ParticipantStatus,
+    RatingConfig,
+    RatingMode,
     Survey,
     SurveyStatus,
     SurveyType,
@@ -78,11 +81,10 @@ def create_survey(
     currency: str = Form("$"),
     db: Session = Depends(get_db),
 ):
-    stype = (
-        SurveyType.van_westendorp
-        if survey_type == "van_westendorp"
-        else SurveyType.conjoint
-    )
+    stype = {
+        "van_westendorp": SurveyType.van_westendorp,
+        "rating": SurveyType.rating,
+    }.get(survey_type, SurveyType.conjoint)
     survey = Survey(
         name=name.strip(),
         description=description.strip(),
@@ -93,6 +95,10 @@ def create_survey(
     if stype == SurveyType.van_westendorp:
         survey.status = SurveyStatus.active
     db.add(survey)
+    db.flush()
+    # Ranking/Rating carries its scale settings in a companion config row.
+    if stype == SurveyType.rating:
+        db.add(RatingConfig(survey_id=survey.id))
     db.commit()
     return RedirectResponse(f"/surveys/{survey.id}", status_code=303)
 
@@ -116,6 +122,7 @@ def manage_survey(survey_id: int, request: Request, db: Session = Depends(get_db
             "email_enabled": settings.email_enabled,
             "SurveyStatus": SurveyStatus,
             "SurveyType": SurveyType,
+            "RatingMode": RatingMode,
             "ParticipantStatus": ParticipantStatus,
         },
     )
@@ -129,6 +136,10 @@ def update_settings(
     alternatives_per_task: str | None = Form(None),
     include_none: bool = Form(False),
     price_attribute_id: str | None = Form(None),
+    rating_mode: str = Form("rate"),
+    scale_points: str | None = Form(None),
+    min_label: str = Form(""),
+    max_label: str = Form(""),
     db: Session = Depends(get_db),
 ):
     survey = _get_survey(db, survey_id)
@@ -144,6 +155,16 @@ def update_settings(
         survey.price_attribute_id = (
             pid if pid in {a.id for a in survey.attributes} else None
         )
+    elif survey.survey_type == SurveyType.rating:
+        cfg = survey.rating_config
+        if cfg is None:
+            cfg = RatingConfig(survey_id=survey.id)
+            db.add(cfg)
+        cfg.mode = RatingMode.rank if rating_mode == "rank" else RatingMode.rate
+        if (sp := _parse_int(scale_points)) is not None:
+            cfg.scale_points = min(11, max(2, sp))
+        cfg.min_label = min_label.strip()[:80]
+        cfg.max_label = max_label.strip()[:80]
     db.commit()
     return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
 
@@ -183,6 +204,45 @@ def delete_attribute(
         if survey.price_attribute_id == attribute.id:
             survey.price_attribute_id = None
         db.delete(attribute)
+        db.commit()
+    return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
+
+
+@router.post("/surveys/{survey_id}/items")
+def add_items(survey_id: int, items: str = Form(...), db: Session = Depends(get_db)):
+    survey = _get_survey(db, survey_id)
+    if survey.survey_type != SurveyType.rating:
+        raise HTTPException(
+            status_code=400, detail="Items apply to ranking/rating surveys."
+        )
+    existing = {it.text.lower() for it in survey.items}
+    position = len(survey.items)
+    for text in _parse_lines(items):
+        if text.lower() in existing:
+            continue
+        db.add(Item(survey_id=survey.id, text=text, position=position))
+        existing.add(text.lower())
+        position += 1
+    db.commit()
+    return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
+
+
+@router.post("/surveys/{survey_id}/items/{item_id}/delete")
+def delete_item(survey_id: int, item_id: int, db: Session = Depends(get_db)):
+    survey = _get_survey(db, survey_id)
+    item = db.get(Item, item_id)
+    if item and item.survey_id == survey.id:
+        db.delete(item)
+        db.commit()
+    return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
+
+
+@router.post("/surveys/{survey_id}/activate")
+def activate_survey(survey_id: int, db: Session = Depends(get_db)):
+    """Activate a ranking/rating survey once it has at least two items."""
+    survey = _get_survey(db, survey_id)
+    if survey.survey_type == SurveyType.rating and len(survey.items) >= 2:
+        survey.status = SurveyStatus.active
         db.commit()
     return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
 
@@ -243,8 +303,13 @@ def close_survey(survey_id: int, db: Session = Depends(get_db)):
 @router.post("/surveys/{survey_id}/reopen")
 def reopen_survey(survey_id: int, db: Session = Depends(get_db)):
     survey = _get_survey(db, survey_id)
-    # Conjoint needs a generated design to be active; VW is always ready.
-    if survey.survey_type == SurveyType.van_westendorp or survey.tasks:
+    # Conjoint needs a generated design; rating needs items; VW is always ready.
+    ready = (
+        survey.survey_type == SurveyType.van_westendorp
+        or bool(survey.tasks)
+        or (survey.survey_type == SurveyType.rating and len(survey.items) >= 2)
+    )
+    if ready:
         survey.status = SurveyStatus.active
         db.commit()
     return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
@@ -265,6 +330,20 @@ def results(survey_id: int, request: Request, db: Session = Depends(get_db)):
             request,
             "admin/results_vw.html",
             {"survey": survey, "results": vw, "error": error},
+        )
+
+    if survey.survey_type == SurveyType.rating:
+        error = None
+        summary = None
+        try:
+            summary = services.run_rating_summary(survey)
+        except ValueError as exc:
+            error = str(exc)
+        return templates.TemplateResponse(
+            request,
+            "admin/results_rating.html",
+            {"survey": survey, "results": summary, "error": error,
+             "RatingMode": RatingMode},
         )
 
     error = None

--- a/app/routes/survey.py
+++ b/app/routes/survey.py
@@ -9,8 +9,18 @@ from sqlalchemy.orm import Session
 
 from .. import van_westendorp
 from ..database import get_db
-from ..models import Participant, ParticipantStatus, SurveyStatus, SurveyType
-from ..services import record_completion, record_price_perception
+from ..models import (
+    Participant,
+    ParticipantStatus,
+    RatingMode,
+    SurveyStatus,
+    SurveyType,
+)
+from ..services import (
+    record_completion,
+    record_item_responses,
+    record_price_perception,
+)
 from ..templating import templates
 
 router = APIRouter()
@@ -43,6 +53,22 @@ def take_survey(token: str, request: Request, db: Session = Depends(get_db)):
             request,
             "survey/van_westendorp.html",
             {"survey": survey, "participant": participant},
+        )
+
+    if survey.survey_type == SurveyType.rating:
+        cfg = survey.rating_config
+        return templates.TemplateResponse(
+            request,
+            "survey/rating.html",
+            {
+                "survey": survey,
+                "participant": participant,
+                "items": survey.items,
+                "config": cfg,
+                "mode": cfg.mode if cfg else RatingMode.rate,
+                "scale_points": cfg.scale_points if cfg else 5,
+                "RatingMode": RatingMode,
+            },
         )
 
     # Build display data: each task with its concepts and per-attribute rows.
@@ -89,6 +115,9 @@ async def submit_survey(token: str, request: Request, db: Session = Depends(get_
 
     if survey.survey_type == SurveyType.van_westendorp:
         return _submit_van_westendorp(request, db, participant, survey, form)
+
+    if survey.survey_type == SurveyType.rating:
+        return _submit_rating(request, db, participant, survey, form)
 
     # Valid concept ids per task, to guard against tampered submissions.
     valid_by_task = {
@@ -182,4 +211,61 @@ def _submit_van_westendorp(request, db, participant, survey, form):
         too_cheap=values["too_cheap"], cheap=values["cheap"],
         expensive=values["expensive"], too_expensive=values["too_expensive"],
     )
+    return RedirectResponse(f"/survey/{participant.token}", status_code=303)
+
+
+def _submit_rating(request, db, participant, survey, form):
+    """Validate and store a Ranking/Rating response (one value per item)."""
+    cfg = survey.rating_config
+    mode = cfg.mode if cfg else RatingMode.rate
+    items = survey.items
+    values: dict[int, int] = {}
+    error = None
+
+    if mode == RatingMode.rank:
+        n = len(items)
+        seen: set[int] = set()
+        for item in items:
+            try:
+                v = int(form.get(f"item_{item.id}"))
+            except (TypeError, ValueError):
+                error = "Please assign a rank to every item."
+                break
+            if v < 1 or v > n or v in seen:
+                error = f"Give each item a unique rank from 1 to {n}."
+                break
+            seen.add(v)
+            values[item.id] = v
+    else:
+        points = cfg.scale_points if cfg else 5
+        for item in items:
+            try:
+                v = int(form.get(f"item_{item.id}"))
+            except (TypeError, ValueError):
+                error = "Please rate every item."
+                break
+            if v < 1 or v > points:
+                error = f"Ratings must be between 1 and {points}."
+                break
+            values[item.id] = v
+
+    if error is not None:
+        return templates.TemplateResponse(
+            request,
+            "survey/rating.html",
+            {
+                "survey": survey,
+                "participant": participant,
+                "items": items,
+                "config": cfg,
+                "mode": mode,
+                "scale_points": cfg.scale_points if cfg else 5,
+                "RatingMode": RatingMode,
+                "error": error,
+                "selected": values,
+            },
+            status_code=400,
+        )
+
+    record_item_responses(db, participant, values)
     return RedirectResponse(f"/survey/{participant.token}", status_code=303)

--- a/app/services.py
+++ b/app/services.py
@@ -6,13 +6,15 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
-from . import analysis, design, van_westendorp
+from . import analysis, design, rating, van_westendorp
 from .models import (
     Concept,
     ConceptLevel,
+    ItemResponse,
     Participant,
     ParticipantStatus,
     PricePerception,
+    RatingMode,
     Response,
     Survey,
     SurveyStatus,
@@ -136,6 +138,48 @@ def record_completion(
                 task_id=task_id,
                 chosen_concept_id=concept_id,
             )
+        )
+    participant.status = ParticipantStatus.completed
+    participant.completed_at = datetime.now(timezone.utc)
+    db.commit()
+
+
+# --- Ranking / Rating -------------------------------------------------------
+
+def gather_item_responses(survey: Survey) -> list[dict[int, int]]:
+    """One {item_id: value} dict per participant that answered."""
+    out: list[dict[int, int]] = []
+    for participant in survey.participants:
+        if participant.item_responses:
+            out.append({ir.item_id: ir.value for ir in participant.item_responses})
+    return out
+
+
+def run_rating_summary(survey: Survey) -> rating.RatingSummary:
+    cfg = survey.rating_config
+    items = [(it.id, it.text) for it in survey.items]
+    if not items:
+        raise ValueError("Add items first.")
+    return rating.summarize(
+        items,
+        gather_item_responses(survey),
+        mode=cfg.mode if cfg else RatingMode.rate,
+        scale_points=cfg.scale_points if cfg else 5,
+        min_label=cfg.min_label if cfg else "",
+        max_label=cfg.max_label if cfg else "",
+    )
+
+
+def record_item_responses(
+    db: Session, participant: Participant, values: dict[int, int]
+) -> None:
+    """Persist a participant's item ratings/ranks (item_id -> value)."""
+    for ir in list(participant.item_responses):
+        db.delete(ir)
+    db.flush()
+    for item_id, value in values.items():
+        db.add(
+            ItemResponse(participant_id=participant.id, item_id=item_id, value=value)
         )
     participant.status = ParticipantStatus.completed
     participant.completed_at = datetime.now(timezone.utc)

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -18,7 +18,7 @@
             <tr>
               <td><a href="/surveys/{{ s.id }}"><strong>{{ s.name }}</strong></a><br>
                 <small class="muted">{{ s.description or "" }}</small></td>
-              <td><small>{% if s.survey_type == SurveyType.van_westendorp %}Van Westendorp{% else %}Conjoint{% endif %}</small></td>
+              <td><small>{% if s.survey_type == SurveyType.van_westendorp %}Van Westendorp{% elif s.survey_type == SurveyType.rating %}Ranking / Rating{% else %}Conjoint{% endif %}</small></td>
               <td><span class="pill {{ s.status.value }}">{{ s.status.value }}</span></td>
               <td>{{ s.participants | length }}</td>
               <td><a class="btn secondary" href="/surveys/{{ s.id }}">Manage</a></td>
@@ -36,7 +36,7 @@
     <form method="post" action="/surveys">
       <label for="name">Name</label>
       <input type="text" id="name" name="name" required placeholder="e.g. Coffee subscription preferences">
-      <label for="description">Description <small class="hint">(shown to respondents for Van Westendorp; otherwise to you only)</small></label>
+      <label for="description">Description <small class="hint">(shown to respondents for Van Westendorp and Ranking/Rating; otherwise to you only)</small></label>
       <textarea id="description" name="description" placeholder="Describe the product."></textarea>
       <div class="row">
         <div>
@@ -44,6 +44,7 @@
           <select id="survey_type" name="survey_type">
             <option value="conjoint">Choice-Based Conjoint</option>
             <option value="van_westendorp">Van Westendorp price sensitivity</option>
+            <option value="rating">Ranking &amp; Rating (matrix)</option>
           </select>
         </div>
         <div>

--- a/app/templates/admin/results_rating.html
+++ b/app/templates/admin/results_rating.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}Results · {{ survey.name }}{% endblock %}
+{% block content %}
+  <p><a href="/surveys/{{ survey.id }}">← Back to survey</a></p>
+  <h1>{% if results and results.mode == RatingMode.rank %}Ranking{% else %}Rating{% endif %}
+    results · {{ survey.name }}</h1>
+
+  {% if error %}
+    <div class="error">{{ error }}</div>
+  {% else %}
+    {% set ncols = results.columns | length %}
+    <div class="card">
+      <p><strong>{{ results.num_responses }}</strong> response(s) ·
+        {% if results.mode == RatingMode.rank %}
+          items ordered by mean rank (lower is better)
+        {% else %}
+          items ordered by mean rating (higher is better)
+        {% endif %}.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Item</th>
+            <th>{% if results.mode == RatingMode.rank %}Mean rank{% else %}Mean{% endif %}</th>
+            <th>n</th>
+            <th>{% if results.mode == RatingMode.rank %}% ranked #1{% else %}% top box{% endif %}</th>
+            <th style="width:220px;">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for it in results.items %}
+            <tr>
+              <td>{{ loop.index }}</td>
+              <td><strong>{{ it.text }}</strong></td>
+              <td>{{ "%.2f"|format(it.mean) }}</td>
+              <td>{{ it.n }}</td>
+              <td>{{ "%.0f"|format(it.top_choice_pct) }}%</td>
+              <td>
+                {% if results.mode == RatingMode.rank %}
+                  {% set frac = (ncols - it.mean + 1) / ncols %}
+                {% else %}
+                  {% set frac = it.mean / ncols %}
+                {% endif %}
+                <div class="bar"><span style="width: {{ (100 * frac) | round(1) }}%;"></span></div>
+                <small class="hint">distribution: {{ it.distribution | join(" / ") }}</small>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p class="muted" style="font-size:13px;">
+        Distribution columns (left → right): {{ results.columns | join(", ") }}{% if results.mode != RatingMode.rank and (results.min_label or results.max_label) %}
+          &nbsp;·&nbsp;{{ results.min_label or "low" }} → {{ results.max_label or "high" }}{% endif %}.
+      </p>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/app/templates/admin/survey.html
+++ b/app/templates/admin/survey.html
@@ -5,7 +5,7 @@
   <h1>{{ survey.name }}
     <span class="pill {{ survey.status.value }}">{{ survey.status.value }}</span></h1>
   <p class="muted">
-    {% if survey.survey_type == SurveyType.van_westendorp %}Van Westendorp price sensitivity{% else %}Choice-Based Conjoint{% endif %}
+    {% if survey.survey_type == SurveyType.van_westendorp %}Van Westendorp price sensitivity{% elif survey.survey_type == SurveyType.rating %}Ranking / Rating{% else %}Choice-Based Conjoint{% endif %}
     {% if survey.description %} · {{ survey.description }}{% endif %}
   </p>
 
@@ -114,7 +114,7 @@
       {% endif %}
     </form>
   </div>
-  {% else %}
+  {% elif survey.survey_type == SurveyType.van_westendorp %}
   <!-- Van Westendorp setup -->
   <div class="card">
     <h2>1 · Price questions</h2>
@@ -130,6 +130,85 @@
         <div><label>&nbsp;</label><button class="secondary btn" type="submit">Save</button></div>
       </div>
     </form>
+  </div>
+  {% else %}
+  <!-- Ranking / Rating setup -->
+  {% set cfg = survey.rating_config %}
+  <div class="card">
+    <h2>1 · Items &amp; scale</h2>
+    <p class="muted">List the items respondents will rate on a shared scale (the
+      matrix) or rank in order. No design step is needed — add items, activate,
+      then invite.</p>
+    <form method="post" action="/surveys/{{ survey.id }}/settings">
+      <div class="row">
+        <div>
+          <label for="rating_mode">Response mode</label>
+          <select id="rating_mode" name="rating_mode">
+            <option value="rate" {% if not cfg or cfg.mode == RatingMode.rate %}selected{% endif %}>Rate each item on a scale (matrix)</option>
+            <option value="rank" {% if cfg and cfg.mode == RatingMode.rank %}selected{% endif %}>Rank items in order</option>
+          </select>
+        </div>
+        <div>
+          <label for="scale_points">Scale points <small class="hint">(rate mode)</small></label>
+          <input type="number" id="scale_points" name="scale_points" min="2" max="11"
+                 value="{{ cfg.scale_points if cfg else 5 }}">
+        </div>
+      </div>
+      <div class="row">
+        <div>
+          <label for="min_label">Low-end label <small class="hint">(optional)</small></label>
+          <input type="text" id="min_label" name="min_label" maxlength="80"
+                 value="{{ cfg.min_label if cfg else '' }}" placeholder="e.g. Strongly disagree">
+        </div>
+        <div>
+          <label for="max_label">High-end label <small class="hint">(optional)</small></label>
+          <input type="text" id="max_label" name="max_label" maxlength="80"
+                 value="{{ cfg.max_label if cfg else '' }}" placeholder="e.g. Strongly agree">
+        </div>
+        <div><label>&nbsp;</label><button class="secondary btn" type="submit">Save scale</button></div>
+      </div>
+    </form>
+
+    <hr style="border:none;border-top:1px solid var(--line);">
+    {% if survey.items %}
+      <table>
+        <thead><tr><th>#</th><th>Item</th><th></th></tr></thead>
+        <tbody>
+          {% for it in survey.items %}
+            <tr>
+              <td>{{ loop.index }}</td>
+              <td>{{ it.text }}</td>
+              <td>
+                <form class="inline" method="post"
+                      action="/surveys/{{ survey.id }}/items/{{ it.id }}/delete"
+                      onsubmit="return confirm('Delete this item?');">
+                  <button class="btn danger" type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="muted">No items yet.</p>
+    {% endif %}
+    <form method="post" action="/surveys/{{ survey.id }}/items">
+      <label for="items">Add items <small class="hint">(one per line or comma-separated)</small></label>
+      <textarea id="items" name="items" required placeholder="Fast support&#10;Lower price&#10;More integrations"></textarea>
+      <p><button type="submit">Add items</button></p>
+    </form>
+
+    <hr style="border:none;border-top:1px solid var(--line);">
+    {% if survey.status == SurveyStatus.draft %}
+      <form method="post" action="/surveys/{{ survey.id }}/activate">
+        <button type="submit" {% if survey.items | length < 2 %}disabled{% endif %}>Activate survey</button>
+        {% if survey.items | length < 2 %}
+          <small class="hint">Add at least two items first.</small>
+        {% endif %}
+      </form>
+    {% else %}
+      <p>✅ Active — collecting responses ({{ survey.items | length }} items).</p>
+    {% endif %}
   </div>
   {% endif %}
 

--- a/app/templates/survey/rating.html
+++ b/app/templates/survey/rating.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}{{ survey.name }}{% endblock %}
+{% block content %}
+  <h1>{{ survey.name }}</h1>
+  {% if survey.description %}<p class="muted">{{ survey.description }}</p>{% endif %}
+
+  {% if error %}<div class="error">{{ error }}</div>{% endif %}
+
+  <form method="post" action="/survey/{{ participant.token }}">
+  {% if mode == RatingMode.rank %}
+    <p class="muted">Rank the items from <strong>1 (best)</strong> to
+      <strong>{{ items | length }} (worst)</strong>. Use each rank only once.</p>
+    <div class="card">
+      <table>
+        <thead><tr><th>Item</th><th style="width:120px;">Rank</th></tr></thead>
+        <tbody>
+          {% for it in items %}
+            <tr>
+              <td>{{ it.text }}</td>
+              <td>
+                <select name="item_{{ it.id }}" required>
+                  <option value="">—</option>
+                  {% for k in range(1, items | length + 1) %}
+                    <option value="{{ k }}" {% if selected and selected.get(it.id) == k %}selected{% endif %}>{{ k }}</option>
+                  {% endfor %}
+                </select>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p class="muted">Rate each item from
+      <strong>1{% if config and config.min_label %} — {{ config.min_label }}{% endif %}</strong>
+      to
+      <strong>{{ scale_points }}{% if config and config.max_label %} — {{ config.max_label }}{% endif %}</strong>.</p>
+    <div class="card" style="overflow-x:auto;">
+      <table>
+        <thead>
+          <tr>
+            <th>Item</th>
+            {% for k in range(1, scale_points + 1) %}
+              <th style="text-align:center;">{{ k }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for it in items %}
+            <tr>
+              <td>{{ it.text }}</td>
+              {% for k in range(1, scale_points + 1) %}
+                <td style="text-align:center;">
+                  <input type="radio" name="item_{{ it.id }}" value="{{ k }}" required
+                         {% if selected and selected.get(it.id) == k %}checked{% endif %}>
+                </td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+    <p><button type="submit">Submit my answers</button></p>
+  </form>
+{% endblock %}

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -18,10 +18,14 @@ from app.database import SessionLocal, init_db
 from app.design import ConceptSpec
 from app.models import (
     Attribute,
+    Item,
+    ItemResponse,
     Level,
     Participant,
     ParticipantStatus,
     PricePerception,
+    RatingConfig,
+    RatingMode,
     Response,
     Survey,
     SurveyStatus,
@@ -153,6 +157,51 @@ def seed(num_participants: int = 60, seed: int = 7) -> None:
         db.commit()
         print(f"Seeded Van Westendorp survey id={vw.id} with {num_participants} responses.")
         print(f"  Results: {settings.effective_base_url}/surveys/{vw.id}/results")
+
+        # --- Ranking / Rating demo -----------------------------------------
+        rating_items = [
+            "Faster customer support",
+            "Lower monthly price",
+            "More integrations",
+            "Better mobile app",
+            "Advanced analytics",
+        ]
+        appeal = [4.4, 4.6, 3.5, 3.9, 3.2]  # simulated mean rating per item (1-5)
+        rt = Survey(
+            name="Feature priorities (demo)",
+            description="Which improvements matter most? Rate each from 1 to 5.",
+            survey_type=SurveyType.rating,
+            status=SurveyStatus.active,
+            currency="$",
+        )
+        db.add(rt)
+        db.flush()
+        db.add(RatingConfig(
+            survey_id=rt.id, mode=RatingMode.rate, scale_points=5,
+            min_label="Not important", max_label="Very important",
+        ))
+        items = []
+        for pos, text in enumerate(rating_items):
+            item = Item(survey_id=rt.id, text=text, position=pos)
+            db.add(item)
+            db.flush()
+            items.append(item)
+        for i in range(num_participants):
+            participant = Participant(
+                survey_id=rt.id,
+                email=f"rate{i + 1}@example.com",
+                status=ParticipantStatus.completed,
+            )
+            db.add(participant)
+            db.flush()
+            for item, mu in zip(items, appeal):
+                value = max(1, min(5, round(rng.gauss(mu, 0.9))))
+                db.add(ItemResponse(
+                    participant_id=participant.id, item_id=item.id, value=value
+                ))
+        db.commit()
+        print(f"Seeded Ranking/Rating survey id={rt.id} with {num_participants} responses.")
+        print(f"  Results: {settings.effective_base_url}/surveys/{rt.id}/results")
 
 
 if __name__ == "__main__":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,14 @@ from sqlalchemy import select
 from app.config import settings
 from app.database import SessionLocal, init_db
 from app.main import app
-from app.models import Participant, ParticipantStatus, Survey, SurveyType
+from app.models import (
+    Participant,
+    ParticipantStatus,
+    RatingMode,
+    Survey,
+    SurveyStatus,
+    SurveyType,
+)
 
 client = TestClient(app)
 
@@ -208,6 +215,103 @@ def test_van_westendorp_full_flow():
     results = client.get(f"/surveys/{sid}/results")
     assert results.status_code == 200
     assert "acceptable prices" in results.text.lower()
+
+
+def test_rating_rate_flow():
+    init_db()
+    client.post("/surveys", data={
+        "name": "Feature priorities", "description": "Rate these.",
+        "survey_type": "rating",
+    })
+    with SessionLocal() as db:
+        survey = db.scalar(select(Survey).where(Survey.name == "Feature priorities"))
+        sid = survey.id
+        assert survey.survey_type == SurveyType.rating
+        assert survey.status == SurveyStatus.draft  # needs items + activation
+        assert survey.rating_config is not None
+
+    client.post(f"/surveys/{sid}/settings", data={
+        "rating_mode": "rate", "scale_points": "5",
+        "min_label": "Low", "max_label": "High", "currency": "$",
+    })
+    client.post(f"/surveys/{sid}/items", data={"items": "Speed\nPrice\nSupport"})
+    client.post(f"/surveys/{sid}/activate")
+    with SessionLocal() as db:
+        survey = db.get(Survey, sid)
+        assert survey.status == SurveyStatus.active
+        assert len(survey.items) == 3
+        item_ids = [it.id for it in survey.items]
+
+    client.post(f"/surveys/{sid}/participants", data={"emails": "ed@example.com"})
+    with SessionLocal() as db:
+        token = db.scalar(
+            select(Participant).where(Participant.email == "ed@example.com")
+        ).token
+
+    page = client.get(f"/survey/{token}")
+    assert page.status_code == 200
+    assert "Rate each item" in page.text
+
+    # An incomplete matrix is rejected.
+    bad = client.post(f"/survey/{token}", data={f"item_{item_ids[0]}": "5"})
+    assert bad.status_code == 400
+
+    form = {f"item_{iid}": str(v) for iid, v in zip(item_ids, [5, 3, 4])}
+    ok = client.post(f"/survey/{token}", data=form)
+    assert ok.status_code == 200
+    assert "Thank you" in ok.text
+
+    with SessionLocal() as db:
+        p = db.scalar(select(Participant).where(Participant.token == token))
+        assert p.status == ParticipantStatus.completed
+        assert len(p.item_responses) == 3
+
+    results = client.get(f"/surveys/{sid}/results")
+    assert results.status_code == 200
+    assert "Rating" in results.text
+
+
+def test_rating_rank_flow():
+    init_db()
+    client.post("/surveys", data={"name": "Rank colors", "survey_type": "rating"})
+    with SessionLocal() as db:
+        sid = db.scalar(select(Survey).where(Survey.name == "Rank colors")).id
+
+    client.post(f"/surveys/{sid}/settings",
+                data={"rating_mode": "rank", "currency": "$"})
+    client.post(f"/surveys/{sid}/items", data={"items": "Red, Green, Blue"})
+    client.post(f"/surveys/{sid}/activate")
+    with SessionLocal() as db:
+        survey = db.get(Survey, sid)
+        assert survey.rating_config.mode == RatingMode.rank
+        item_ids = [it.id for it in survey.items]
+
+    client.post(f"/surveys/{sid}/participants", data={"emails": "fi@example.com"})
+    with SessionLocal() as db:
+        token = db.scalar(
+            select(Participant).where(Participant.email == "fi@example.com")
+        ).token
+
+    page = client.get(f"/survey/{token}")
+    assert "Rank the items" in page.text
+
+    # Duplicate ranks are rejected.
+    dup = client.post(f"/survey/{token}", data={
+        f"item_{item_ids[0]}": "1", f"item_{item_ids[1]}": "1",
+        f"item_{item_ids[2]}": "2",
+    })
+    assert dup.status_code == 400
+
+    ok = client.post(f"/survey/{token}", data={
+        f"item_{item_ids[0]}": "2", f"item_{item_ids[1]}": "1",
+        f"item_{item_ids[2]}": "3",
+    })
+    assert ok.status_code == 200
+    assert "Thank you" in ok.text
+
+    results = client.get(f"/surveys/{sid}/results")
+    assert results.status_code == 200
+    assert "Ranking" in results.text
 
 
 def test_market_simulator():

--- a/tests/test_rating.py
+++ b/tests/test_rating.py
@@ -1,0 +1,47 @@
+"""Unit tests for Ranking / Rating summaries."""
+
+import pytest
+
+from app.models import RatingMode
+from app.rating import summarize
+
+
+def test_rate_summary_orders_by_mean_descending():
+    items = [(1, "A"), (2, "B"), (3, "C")]
+    responses = [
+        {1: 5, 2: 3, 3: 1},
+        {1: 4, 2: 3, 3: 2},
+        {1: 5, 2: 2, 3: 1},
+    ]
+    s = summarize(items, responses, mode=RatingMode.rate, scale_points=5)
+
+    assert s.num_responses == 3
+    assert s.columns == ["1", "2", "3", "4", "5"]
+    assert [i.item_id for i in s.items] == [1, 2, 3]  # A best, C worst
+
+    a = s.items[0]
+    assert abs(a.mean - 14 / 3) < 1e-9
+    assert a.distribution == [0, 0, 0, 1, 2]   # one 4, two 5s
+    assert abs(a.top_choice_pct - 2 / 3 * 100) < 1e-9  # top box (5) twice
+
+
+def test_rank_summary_orders_by_mean_ascending():
+    items = [(1, "A"), (2, "B"), (3, "C")]
+    responses = [
+        {1: 1, 2: 2, 3: 3},
+        {1: 2, 2: 1, 3: 3},
+        {1: 1, 2: 3, 3: 2},
+    ]
+    s = summarize(items, responses, mode=RatingMode.rank, scale_points=0)
+
+    assert s.columns == ["1", "2", "3"]      # rank positions
+    assert s.items[0].item_id == 1           # lowest mean rank wins
+    a = s.items[0]
+    assert abs(a.mean - 4 / 3) < 1e-9
+    assert a.distribution == [2, 1, 0]       # ranked 1 twice, 2 once
+    assert abs(a.top_choice_pct - 2 / 3 * 100) < 1e-9  # ranked #1 twice
+
+
+def test_no_responses_raises():
+    with pytest.raises(ValueError):
+        summarize([(1, "A")], [], mode=RatingMode.rate, scale_points=5)


### PR DESCRIPTION
## Summary

First of the four new survey types (one PR per type). Adds a **Ranking / Rating** survey: the researcher defines a list of items, and respondents either:

- **Rate** each item on a shared scale — the **matrix grid** (configurable 2–11 points, with optional low/high endpoint labels), or
- **Rank** the items in order (1 = best … N = worst).

Results show per-item **mean, distribution, and top-choice share** (top-box for rate, % ranked #1 for rank), sorted best-first.

## Deploy safety (no migrations framework)

The schema change is **purely additive** so it's safe on the live SQLite DB, where `init_db()` uses `create_all` (which only creates missing **tables**, never alters existing ones):

- New tables only: `items`, `item_responses`, `rating_configs`. **No new columns on `surveys`** (rating settings live in the companion `rating_configs` table).
- Simulated an existing pre-rating DB → startup added exactly those three tables and left existing data and the `surveys` schema untouched.

## What's included

- **models**: `SurveyType.rating`, `RatingMode` (rate/rank), `Item`, `ItemResponse`, `RatingConfig` + relationships.
- **rating.py**: per-item summary (mean, distribution, top-choice), best-first ordering.
- **admin**: create flow, scale/mode settings, add/delete items, activate, build UI, and a results page.
- **survey (respondent)**: matrix radio grid (rate) and per-item rank selects (rank), with server-side validation (complete matrix; ranks must be a unique permutation).
- **seed_demo**: adds a Ranking/Rating demo; **README** documents the type.

## Testing

- `pytest` → **35 passing** (added rate + rank end-to-end flows and `rating.summarize` unit tests).
- Live smoke test through `uvicorn`: created a rating survey, configured the scale, added items, activated, submitted the matrix, and rendered the results page — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMQ2LNzm9UvwVaBwrDXL4U)_