### PR TITLE
Add MaxDiff (best-worst scaling) survey type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ FastAPI app.
     on a shared scale (the matrix grid, with optional endpoint labels) or
     **rank** in order; results show mean, distribution, and top-choice share
     per item.
+  - **MaxDiff** (best-worst scaling) — define items, auto-generate a
+    count-balanced design of small sets, and respondents pick the **best** and
+    **worst** in each; results report the best-minus-worst score per item.
 - **Invite participants by email** — each respondent gets a unique survey link.
   Works with any SMTP provider, or runs in a no-credentials *console mode* for
   local development.

--- a/app/maxdiff.py
+++ b/app/maxdiff.py
@@ -1,0 +1,129 @@
+"""MaxDiff (best-worst scaling) design generation and counting analysis.
+
+Design: respondents see a series of small *sets*, each a subset of the items,
+and pick the **best** and **worst** item in each. We generate a count-balanced
+design so every item appears a similar number of times and no item repeats
+within a set.
+
+Analysis (counting model): for each item we tally how often it was shown, picked
+best, and picked worst. The standard **best-minus-worst score** is
+
+    score = (best_count - worst_count) / appearances        (range -1 .. +1)
+
+Items are reported sorted best-first. (A multinomial/rank-ordered logit model is
+a natural future extension; counting is the widely used, transparent baseline.)
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+
+def suggested_num_sets(n_items: int, items_per_set: int) -> int:
+    """A reasonable default: enough sets for each item to appear ~3 times."""
+    if n_items <= 0 or items_per_set <= 0:
+        return 0
+    import math
+
+    return max(1, math.ceil(3 * n_items / items_per_set))
+
+
+def generate_design(
+    n_items: int,
+    items_per_set: int,
+    num_sets: int,
+    seed: int | None = None,
+) -> list[list[int]]:
+    """Return ``num_sets`` sets of distinct item indices (0..n_items-1).
+
+    Greedy count balancing: each set takes the least-used items so far (random
+    tie-break), keeping appearances even and items within a set distinct.
+    """
+    if items_per_set < 2:
+        raise ValueError("A MaxDiff set needs at least 2 items.")
+    if items_per_set > n_items:
+        raise ValueError("Items per set cannot exceed the number of items.")
+    if num_sets < 1:
+        raise ValueError("Need at least one set.")
+
+    rng = random.Random(seed)
+    counts = [0] * n_items
+    sets: list[list[int]] = []
+    for _ in range(num_sets):
+        order = sorted(range(n_items), key=lambda i: (counts[i], rng.random()))
+        chosen = order[:items_per_set]
+        for i in chosen:
+            counts[i] += 1
+        rng.shuffle(chosen)
+        sets.append(chosen)
+    return sets
+
+
+@dataclass
+class MaxDiffItemResult:
+    item_id: int
+    text: str
+    appearances: int
+    best: int
+    worst: int
+    score: float      # (best - worst) / appearances
+    best_pct: float   # best / appearances * 100
+    worst_pct: float  # worst / appearances * 100
+
+
+@dataclass
+class MaxDiffResults:
+    num_responses: int
+    items: list[MaxDiffItemResult]  # sorted best-first
+
+
+@dataclass
+class Observation:
+    shown: list[int]  # item ids shown in the set
+    best: int         # item id picked best
+    worst: int        # item id picked worst
+
+
+def summarize(
+    items: list[tuple[int, str]],
+    observations: list[Observation],
+    num_responses: int,
+) -> MaxDiffResults:
+    """Counting analysis over best/worst picks. Raises if there are none."""
+    if not observations:
+        raise ValueError("No responses yet.")
+
+    appearances: dict[int, int] = {item_id: 0 for item_id, _ in items}
+    best: dict[int, int] = {item_id: 0 for item_id, _ in items}
+    worst: dict[int, int] = {item_id: 0 for item_id, _ in items}
+
+    for obs in observations:
+        for item_id in obs.shown:
+            if item_id in appearances:
+                appearances[item_id] += 1
+        if obs.best in best:
+            best[obs.best] += 1
+        if obs.worst in worst:
+            worst[obs.worst] += 1
+
+    results: list[MaxDiffItemResult] = []
+    for item_id, text in items:
+        apps = appearances[item_id]
+        b, w = best[item_id], worst[item_id]
+        score = ((b - w) / apps) if apps else 0.0
+        results.append(
+            MaxDiffItemResult(
+                item_id=item_id,
+                text=text,
+                appearances=apps,
+                best=b,
+                worst=w,
+                score=score,
+                best_pct=(100.0 * b / apps) if apps else 0.0,
+                worst_pct=(100.0 * w / apps) if apps else 0.0,
+            )
+        )
+
+    results.sort(key=lambda r: r.score, reverse=True)
+    return MaxDiffResults(num_responses=num_responses, items=results)

--- a/app/models.py
+++ b/app/models.py
@@ -42,6 +42,7 @@ class SurveyType(str, enum.Enum):
     conjoint = "conjoint"              # Choice-Based Conjoint
     van_westendorp = "van_westendorp"  # Price Sensitivity Meter
     rating = "rating"                  # Ranking / Rating (matrix)
+    maxdiff = "maxdiff"                # MaxDiff (best-worst scaling)
 
 
 class RatingMode(str, enum.Enum):
@@ -109,6 +110,16 @@ class Survey(Base):
         back_populates="survey",
         cascade="all, delete-orphan",
         uselist=False,
+    )
+    maxdiff_config: Mapped["MaxDiffConfig | None"] = relationship(
+        back_populates="survey",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+    maxdiff_sets: Mapped[list["MaxDiffSet"]] = relationship(
+        back_populates="survey",
+        cascade="all, delete-orphan",
+        order_by="MaxDiffSet.position",
     )
     participants: Mapped[list["Participant"]] = relationship(
         back_populates="survey", cascade="all, delete-orphan"
@@ -264,6 +275,83 @@ class ItemResponse(Base):
     item: Mapped[Item] = relationship(back_populates="responses")
 
 
+class MaxDiffConfig(Base):
+    """Per-survey settings for a MaxDiff (best-worst) survey."""
+
+    __tablename__ = "maxdiff_configs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    survey_id: Mapped[int] = mapped_column(
+        ForeignKey("surveys.id", ondelete="CASCADE"), unique=True
+    )
+    items_per_set: Mapped[int] = mapped_column(Integer, default=4)
+    num_sets: Mapped[int] = mapped_column(Integer, default=0)  # 0 = auto
+
+    survey: Mapped[Survey] = relationship(back_populates="maxdiff_config")
+
+
+class MaxDiffSet(Base):
+    """One screen of a MaxDiff design: a subset of items shown together."""
+
+    __tablename__ = "maxdiff_sets"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    survey_id: Mapped[int] = mapped_column(
+        ForeignKey("surveys.id", ondelete="CASCADE")
+    )
+    position: Mapped[int] = mapped_column(Integer, default=0)
+
+    survey: Mapped[Survey] = relationship(back_populates="maxdiff_sets")
+    set_items: Mapped[list["MaxDiffSetItem"]] = relationship(
+        back_populates="set",
+        cascade="all, delete-orphan",
+        order_by="MaxDiffSetItem.position",
+    )
+
+
+class MaxDiffSetItem(Base):
+    """Membership of an item in a MaxDiff set."""
+
+    __tablename__ = "maxdiff_set_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    set_id: Mapped[int] = mapped_column(
+        ForeignKey("maxdiff_sets.id", ondelete="CASCADE")
+    )
+    item_id: Mapped[int] = mapped_column(ForeignKey("items.id", ondelete="CASCADE"))
+    position: Mapped[int] = mapped_column(Integer, default=0)
+
+    set: Mapped[MaxDiffSet] = relationship(back_populates="set_items")
+    item: Mapped["Item"] = relationship()
+
+
+class MaxDiffResponse(Base):
+    """A respondent's best & worst pick for one MaxDiff set."""
+
+    __tablename__ = "maxdiff_responses"
+    __table_args__ = (
+        UniqueConstraint(
+            "participant_id", "set_id", name="uq_maxdiff_response_participant_set"
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    participant_id: Mapped[int] = mapped_column(
+        ForeignKey("participants.id", ondelete="CASCADE")
+    )
+    set_id: Mapped[int] = mapped_column(
+        ForeignKey("maxdiff_sets.id", ondelete="CASCADE")
+    )
+    best_item_id: Mapped[int] = mapped_column(ForeignKey("items.id"))
+    worst_item_id: Mapped[int] = mapped_column(ForeignKey("items.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+    participant: Mapped["Participant"] = relationship(
+        back_populates="maxdiff_responses"
+    )
+    set: Mapped[MaxDiffSet] = relationship()
+
+
 class Participant(Base):
     __tablename__ = "participants"
     __table_args__ = (
@@ -289,6 +377,9 @@ class Participant(Base):
         back_populates="participant", cascade="all, delete-orphan"
     )
     item_responses: Mapped[list["ItemResponse"]] = relationship(
+        back_populates="participant", cascade="all, delete-orphan"
+    )
+    maxdiff_responses: Mapped[list["MaxDiffResponse"]] = relationship(
         back_populates="participant", cascade="all, delete-orphan"
     )
     price_perception: Mapped["PricePerception | None"] = relationship(

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -18,6 +18,7 @@ from ..models import (
     Attribute,
     Item,
     Level,
+    MaxDiffConfig,
     Participant,
     ParticipantStatus,
     RatingConfig,
@@ -84,6 +85,7 @@ def create_survey(
     stype = {
         "van_westendorp": SurveyType.van_westendorp,
         "rating": SurveyType.rating,
+        "maxdiff": SurveyType.maxdiff,
     }.get(survey_type, SurveyType.conjoint)
     survey = Survey(
         name=name.strip(),
@@ -96,9 +98,11 @@ def create_survey(
         survey.status = SurveyStatus.active
     db.add(survey)
     db.flush()
-    # Ranking/Rating carries its scale settings in a companion config row.
+    # Type-specific settings live in companion config rows (additive schema).
     if stype == SurveyType.rating:
         db.add(RatingConfig(survey_id=survey.id))
+    elif stype == SurveyType.maxdiff:
+        db.add(MaxDiffConfig(survey_id=survey.id))
     db.commit()
     return RedirectResponse(f"/surveys/{survey.id}", status_code=303)
 
@@ -112,6 +116,9 @@ def manage_survey(survey_id: int, request: Request, db: Session = Depends(get_db
     can_generate = len(survey.attributes) >= 1 and all(
         len(a.levels) >= 2 for a in survey.attributes
     )
+    if survey.survey_type == SurveyType.maxdiff:
+        k = survey.maxdiff_config.items_per_set if survey.maxdiff_config else 4
+        can_generate = len(survey.items) >= max(3, k)
     return templates.TemplateResponse(
         request,
         "admin/survey.html",
@@ -140,6 +147,8 @@ def update_settings(
     scale_points: str | None = Form(None),
     min_label: str = Form(""),
     max_label: str = Form(""),
+    items_per_set: str | None = Form(None),
+    num_sets: str | None = Form(None),
     db: Session = Depends(get_db),
 ):
     survey = _get_survey(db, survey_id)
@@ -165,6 +174,15 @@ def update_settings(
             cfg.scale_points = min(11, max(2, sp))
         cfg.min_label = min_label.strip()[:80]
         cfg.max_label = max_label.strip()[:80]
+    elif survey.survey_type == SurveyType.maxdiff:
+        cfg = survey.maxdiff_config
+        if cfg is None:
+            cfg = MaxDiffConfig(survey_id=survey.id)
+            db.add(cfg)
+        if (ips := _parse_int(items_per_set)) is not None:
+            cfg.items_per_set = max(2, ips)
+        if (ns := _parse_int(num_sets)) is not None:
+            cfg.num_sets = max(0, ns)  # 0 = auto
     db.commit()
     return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
 
@@ -211,9 +229,9 @@ def delete_attribute(
 @router.post("/surveys/{survey_id}/items")
 def add_items(survey_id: int, items: str = Form(...), db: Session = Depends(get_db)):
     survey = _get_survey(db, survey_id)
-    if survey.survey_type != SurveyType.rating:
+    if survey.survey_type not in (SurveyType.rating, SurveyType.maxdiff):
         raise HTTPException(
-            status_code=400, detail="Items apply to ranking/rating surveys."
+            status_code=400, detail="Items apply to ranking/rating and MaxDiff surveys."
         )
     existing = {it.text.lower() for it in survey.items}
     position = len(survey.items)
@@ -250,11 +268,21 @@ def activate_survey(survey_id: int, db: Session = Depends(get_db)):
 @router.post("/surveys/{survey_id}/generate")
 def generate_design(survey_id: int, db: Session = Depends(get_db)):
     survey = _get_survey(db, survey_id)
-    if survey.survey_type != SurveyType.conjoint:
-        raise HTTPException(status_code=400, detail="Only conjoint surveys have a design.")
-    if not survey.attributes:
-        raise HTTPException(status_code=400, detail="Add attributes first.")
-    services.generate_and_store_design(db, survey)
+    if survey.survey_type == SurveyType.conjoint:
+        if not survey.attributes:
+            raise HTTPException(status_code=400, detail="Add attributes first.")
+        services.generate_and_store_design(db, survey)
+    elif survey.survey_type == SurveyType.maxdiff:
+        cfg = survey.maxdiff_config
+        k = cfg.items_per_set if cfg else 4
+        if len(survey.items) < k:
+            raise HTTPException(
+                status_code=400,
+                detail="Add at least as many items as items-per-set first.",
+            )
+        services.generate_and_store_maxdiff(db, survey)
+    else:
+        raise HTTPException(status_code=400, detail="This survey has no design step.")
     return RedirectResponse(f"/surveys/{survey_id}", status_code=303)
 
 
@@ -308,6 +336,7 @@ def reopen_survey(survey_id: int, db: Session = Depends(get_db)):
         survey.survey_type == SurveyType.van_westendorp
         or bool(survey.tasks)
         or (survey.survey_type == SurveyType.rating and len(survey.items) >= 2)
+        or (survey.survey_type == SurveyType.maxdiff and bool(survey.maxdiff_sets))
     )
     if ready:
         survey.status = SurveyStatus.active
@@ -344,6 +373,19 @@ def results(survey_id: int, request: Request, db: Session = Depends(get_db)):
             "admin/results_rating.html",
             {"survey": survey, "results": summary, "error": error,
              "RatingMode": RatingMode},
+        )
+
+    if survey.survey_type == SurveyType.maxdiff:
+        error = None
+        summary = None
+        try:
+            summary = services.run_maxdiff_summary(survey)
+        except ValueError as exc:
+            error = str(exc)
+        return templates.TemplateResponse(
+            request,
+            "admin/results_maxdiff.html",
+            {"survey": survey, "results": summary, "error": error},
         )
 
     error = None

--- a/app/routes/survey.py
+++ b/app/routes/survey.py
@@ -19,6 +19,7 @@ from ..models import (
 from ..services import (
     record_completion,
     record_item_responses,
+    record_maxdiff_responses,
     record_price_perception,
 )
 from ..templating import templates
@@ -71,6 +72,24 @@ def take_survey(token: str, request: Request, db: Session = Depends(get_db)):
             },
         )
 
+    if survey.survey_type == SurveyType.maxdiff:
+        sets = [
+            {
+                "id": mset.id,
+                "position": mset.position + 1,
+                "options": [
+                    {"id": si.item.id, "text": si.item.text}
+                    for si in mset.set_items
+                ],
+            }
+            for mset in survey.maxdiff_sets
+        ]
+        return templates.TemplateResponse(
+            request,
+            "survey/maxdiff.html",
+            {"survey": survey, "participant": participant, "sets": sets},
+        )
+
     # Build display data: each task with its concepts and per-attribute rows.
     attributes = [a.name for a in survey.attributes]
     tasks = []
@@ -118,6 +137,9 @@ async def submit_survey(token: str, request: Request, db: Session = Depends(get_
 
     if survey.survey_type == SurveyType.rating:
         return _submit_rating(request, db, participant, survey, form)
+
+    if survey.survey_type == SurveyType.maxdiff:
+        return _submit_maxdiff(request, db, participant, survey, form)
 
     # Valid concept ids per task, to guard against tampered submissions.
     valid_by_task = {
@@ -268,4 +290,57 @@ def _submit_rating(request, db, participant, survey, form):
         )
 
     record_item_responses(db, participant, values)
+    return RedirectResponse(f"/survey/{participant.token}", status_code=303)
+
+
+def _submit_maxdiff(request, db, participant, survey, form):
+    """Validate and store best/worst picks for every MaxDiff set."""
+    picks: dict[int, tuple[int, int]] = {}
+    error = None
+
+    for mset in survey.maxdiff_sets:
+        member_ids = {si.item_id for si in mset.set_items}
+        try:
+            best = int(form.get(f"best_{mset.id}"))
+            worst = int(form.get(f"worst_{mset.id}"))
+        except (TypeError, ValueError):
+            error = "Please pick a best and a worst item in every set."
+            break
+        if best not in member_ids or worst not in member_ids:
+            error = "Please choose items from within each set."
+            break
+        if best == worst:
+            error = "The best and worst item in a set must be different."
+            break
+        picks[mset.id] = (best, worst)
+
+    if error is not None:
+        sets = [
+            {
+                "id": mset.id,
+                "position": mset.position + 1,
+                "options": [
+                    {"id": si.item.id, "text": si.item.text}
+                    for si in mset.set_items
+                ],
+            }
+            for mset in survey.maxdiff_sets
+        ]
+        selected = {
+            sid: {"best": b, "worst": w} for sid, (b, w) in picks.items()
+        }
+        return templates.TemplateResponse(
+            request,
+            "survey/maxdiff.html",
+            {
+                "survey": survey,
+                "participant": participant,
+                "sets": sets,
+                "error": error,
+                "selected": selected,
+            },
+            status_code=400,
+        )
+
+    record_maxdiff_responses(db, participant, picks)
     return RedirectResponse(f"/survey/{participant.token}", status_code=303)

--- a/app/services.py
+++ b/app/services.py
@@ -6,11 +6,14 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
-from . import analysis, design, rating, van_westendorp
+from . import analysis, design, maxdiff, rating, van_westendorp
 from .models import (
     Concept,
     ConceptLevel,
     ItemResponse,
+    MaxDiffResponse,
+    MaxDiffSet,
+    MaxDiffSetItem,
     Participant,
     ParticipantStatus,
     PricePerception,
@@ -180,6 +183,85 @@ def record_item_responses(
     for item_id, value in values.items():
         db.add(
             ItemResponse(participant_id=participant.id, item_id=item_id, value=value)
+        )
+    participant.status = ParticipantStatus.completed
+    participant.completed_at = datetime.now(timezone.utc)
+    db.commit()
+
+
+# --- MaxDiff ----------------------------------------------------------------
+
+def generate_and_store_maxdiff(
+    db: Session, survey: Survey, seed: int | None = None
+) -> None:
+    """(Re)generate the MaxDiff design and persist sets. Clears prior sets."""
+    cfg = survey.maxdiff_config
+    items = list(survey.items)
+    n = len(items)
+    k = cfg.items_per_set if cfg else 4
+    num_sets = (cfg.num_sets if cfg and cfg.num_sets else 0) or \
+        maxdiff.suggested_num_sets(n, k)
+
+    design_sets = maxdiff.generate_design(n, k, num_sets, seed=seed)
+
+    for mset in list(survey.maxdiff_sets):
+        db.delete(mset)
+    db.flush()
+
+    for s_pos, item_indices in enumerate(design_sets):
+        mset = MaxDiffSet(survey_id=survey.id, position=s_pos)
+        db.add(mset)
+        db.flush()
+        for i_pos, idx in enumerate(item_indices):
+            db.add(
+                MaxDiffSetItem(set_id=mset.id, item_id=items[idx].id, position=i_pos)
+            )
+
+    survey.status = SurveyStatus.active
+    db.commit()
+
+
+def gather_maxdiff_observations(survey: Survey) -> list[maxdiff.Observation]:
+    set_items = {
+        mset.id: [si.item_id for si in mset.set_items] for mset in survey.maxdiff_sets
+    }
+    out: list[maxdiff.Observation] = []
+    for participant in survey.participants:
+        for resp in participant.maxdiff_responses:
+            shown = set_items.get(resp.set_id, [])
+            out.append(
+                maxdiff.Observation(
+                    shown=shown, best=resp.best_item_id, worst=resp.worst_item_id
+                )
+            )
+    return out
+
+
+def run_maxdiff_summary(survey: Survey) -> maxdiff.MaxDiffResults:
+    items = [(it.id, it.text) for it in survey.items]
+    if not items:
+        raise ValueError("Add items first.")
+    num_responses = sum(
+        1 for p in survey.participants if p.maxdiff_responses
+    )
+    return maxdiff.summarize(items, gather_maxdiff_observations(survey), num_responses)
+
+
+def record_maxdiff_responses(
+    db: Session, participant: Participant, picks: dict[int, tuple[int, int]]
+) -> None:
+    """Persist best/worst picks per set (set_id -> (best_item_id, worst_item_id))."""
+    for resp in list(participant.maxdiff_responses):
+        db.delete(resp)
+    db.flush()
+    for set_id, (best_id, worst_id) in picks.items():
+        db.add(
+            MaxDiffResponse(
+                participant_id=participant.id,
+                set_id=set_id,
+                best_item_id=best_id,
+                worst_item_id=worst_id,
+            )
         )
     participant.status = ParticipantStatus.completed
     participant.completed_at = datetime.now(timezone.utc)

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -18,7 +18,7 @@
             <tr>
               <td><a href="/surveys/{{ s.id }}"><strong>{{ s.name }}</strong></a><br>
                 <small class="muted">{{ s.description or "" }}</small></td>
-              <td><small>{% if s.survey_type == SurveyType.van_westendorp %}Van Westendorp{% elif s.survey_type == SurveyType.rating %}Ranking / Rating{% else %}Conjoint{% endif %}</small></td>
+              <td><small>{% if s.survey_type == SurveyType.van_westendorp %}Van Westendorp{% elif s.survey_type == SurveyType.rating %}Ranking / Rating{% elif s.survey_type == SurveyType.maxdiff %}MaxDiff{% else %}Conjoint{% endif %}</small></td>
               <td><span class="pill {{ s.status.value }}">{{ s.status.value }}</span></td>
               <td>{{ s.participants | length }}</td>
               <td><a class="btn secondary" href="/surveys/{{ s.id }}">Manage</a></td>
@@ -45,6 +45,7 @@
             <option value="conjoint">Choice-Based Conjoint</option>
             <option value="van_westendorp">Van Westendorp price sensitivity</option>
             <option value="rating">Ranking &amp; Rating (matrix)</option>
+            <option value="maxdiff">MaxDiff (best-worst)</option>
           </select>
         </div>
         <div>

--- a/app/templates/admin/results_maxdiff.html
+++ b/app/templates/admin/results_maxdiff.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}Results · {{ survey.name }}{% endblock %}
+{% block content %}
+  <p><a href="/surveys/{{ survey.id }}">← Back to survey</a></p>
+  <h1>MaxDiff results · {{ survey.name }}</h1>
+
+  {% if error %}
+    <div class="error">{{ error }}</div>
+  {% else %}
+    <div class="card">
+      <p><strong>{{ results.num_responses }}</strong> response(s) ·
+        items ordered by best-minus-worst score (higher is better).</p>
+      <table>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Item</th>
+            <th>Score</th>
+            <th>Best %</th>
+            <th>Worst %</th>
+            <th>Shown</th>
+            <th style="width:200px;">B−W</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for it in results.items %}
+            <tr>
+              <td>{{ loop.index }}</td>
+              <td><strong>{{ it.text }}</strong></td>
+              <td>{{ "%+.2f"|format(it.score) }}</td>
+              <td>{{ "%.0f"|format(it.best_pct) }}%</td>
+              <td>{{ "%.0f"|format(it.worst_pct) }}%</td>
+              <td>{{ it.appearances }}</td>
+              <td>
+                {# Center bar: score in -1..+1 mapped onto a 0..100% axis. #}
+                {% set pos = (it.score + 1) / 2 * 100 %}
+                <div style="position:relative; height:16px; background:#f0ece3; border-radius:4px;">
+                  <div style="position:absolute; left:50%; top:0; bottom:0; width:1px; background:#bbb;"></div>
+                  {% if it.score >= 0 %}
+                    <div style="position:absolute; left:50%; top:0; bottom:0; width:{{ (pos - 50)|round(1) }}%; background:#2e7d32; border-radius:0 4px 4px 0;"></div>
+                  {% else %}
+                    <div style="position:absolute; right:50%; top:0; bottom:0; width:{{ (50 - pos)|round(1) }}%; background:#c62828; border-radius:4px 0 0 4px;"></div>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p class="muted" style="font-size:13px;">
+        Score = (times picked best − times picked worst) ÷ times shown, ranging
+        −1 to +1. "Shown" is the total number of times the item appeared across
+        all respondents.
+      </p>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/app/templates/admin/survey.html
+++ b/app/templates/admin/survey.html
@@ -5,9 +5,11 @@
   <h1>{{ survey.name }}
     <span class="pill {{ survey.status.value }}">{{ survey.status.value }}</span></h1>
   <p class="muted">
-    {% if survey.survey_type == SurveyType.van_westendorp %}Van Westendorp price sensitivity{% elif survey.survey_type == SurveyType.rating %}Ranking / Rating{% else %}Choice-Based Conjoint{% endif %}
+    {% if survey.survey_type == SurveyType.van_westendorp %}Van Westendorp price sensitivity{% elif survey.survey_type == SurveyType.rating %}Ranking / Rating{% elif survey.survey_type == SurveyType.maxdiff %}MaxDiff (best-worst){% else %}Choice-Based Conjoint{% endif %}
     {% if survey.description %} · {{ survey.description }}{% endif %}
   </p>
+  {# Types with a design-generation step number their cards 1-4; others 1-3. #}
+  {% set two_step = survey.survey_type in [SurveyType.conjoint, SurveyType.maxdiff] %}
 
   {% if survey.survey_type == SurveyType.conjoint %}
   <!-- Attributes (conjoint only) -->
@@ -131,7 +133,7 @@
       </div>
     </form>
   </div>
-  {% else %}
+  {% elif survey.survey_type == SurveyType.rating %}
   <!-- Ranking / Rating setup -->
   {% set cfg = survey.rating_config %}
   <div class="card">
@@ -210,11 +212,82 @@
       <p>✅ Active — collecting responses ({{ survey.items | length }} items).</p>
     {% endif %}
   </div>
+  {% else %}
+  <!-- MaxDiff setup -->
+  {% set mcfg = survey.maxdiff_config %}
+  <div class="card">
+    <h2>1 · Items</h2>
+    <p class="muted">List the items respondents will compare. Each MaxDiff screen
+      shows a small subset; respondents pick the best and worst in each.</p>
+    {% if survey.items %}
+      <table>
+        <thead><tr><th>#</th><th>Item</th><th></th></tr></thead>
+        <tbody>
+          {% for it in survey.items %}
+            <tr>
+              <td>{{ loop.index }}</td>
+              <td>{{ it.text }}</td>
+              <td>
+                <form class="inline" method="post"
+                      action="/surveys/{{ survey.id }}/items/{{ it.id }}/delete"
+                      onsubmit="return confirm('Delete this item?');">
+                  <button class="btn danger" type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="muted">No items yet.</p>
+    {% endif %}
+    <form method="post" action="/surveys/{{ survey.id }}/items">
+      <label for="items">Add items <small class="hint">(one per line or comma-separated)</small></label>
+      <textarea id="items" name="items" required placeholder="Fast support&#10;Lower price&#10;More integrations&#10;Better mobile app"></textarea>
+      <p><button type="submit">Add items</button></p>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>2 · Design (sets)</h2>
+    <form method="post" action="/surveys/{{ survey.id }}/settings">
+      <div class="row">
+        <div>
+          <label for="items_per_set">Items per set</label>
+          <input type="number" id="items_per_set" name="items_per_set" min="2" max="8"
+                 value="{{ mcfg.items_per_set if mcfg else 4 }}">
+        </div>
+        <div>
+          <label for="num_sets">Number of sets <small class="hint">(0 = auto)</small></label>
+          <input type="number" id="num_sets" name="num_sets" min="0" max="50"
+                 value="{{ mcfg.num_sets if mcfg else 0 }}">
+        </div>
+        <div><label>&nbsp;</label><button class="secondary btn" type="submit">Save design settings</button></div>
+      </div>
+    </form>
+
+    <hr style="border:none;border-top:1px solid var(--line);">
+    {% if survey.maxdiff_sets %}
+      <p>✅ Design generated: <strong>{{ survey.maxdiff_sets | length }}</strong> sets
+        of <strong>{{ mcfg.items_per_set if mcfg else 4 }}</strong> items each.</p>
+    {% else %}
+      <p class="muted">No design generated yet.</p>
+    {% endif %}
+    <form method="post" action="/surveys/{{ survey.id }}/generate"
+          onsubmit="return confirm('Generate (or regenerate) the design? This clears any existing responses.');">
+      <button type="submit" {% if not can_generate %}disabled{% endif %}>
+        {% if survey.maxdiff_sets %}Regenerate design{% else %}Generate design{% endif %}
+      </button>
+      {% if not can_generate %}
+        <small class="hint">Add at least as many items as items-per-set (3+).</small>
+      {% endif %}
+    </form>
+  </div>
   {% endif %}
 
   <!-- Participants -->
   <div class="card">
-    <h2>{% if survey.survey_type == SurveyType.conjoint %}3{% else %}2{% endif %} · Participants</h2>
+    <h2>{% if two_step %}3{% else %}2{% endif %} · Participants</h2>
     {% if not email_enabled %}
       <p class="notice">Console email mode — invitations are saved to
         <code>dev_outbox/</code>. Use each participant's link below to test.</p>
@@ -238,7 +311,7 @@
           ✉ Send invitations
         </button>
         {% if survey.status != SurveyStatus.active %}
-          <small class="hint">{% if survey.survey_type == SurveyType.conjoint %}Generate the design first.{% else %}Survey must be active.{% endif %}</small>
+          <small class="hint">{% if two_step %}Generate the design first.{% else %}Survey must be active.{% endif %}</small>
         {% endif %}
       </form>
     {% else %}
@@ -254,7 +327,7 @@
 
   <!-- Results / status -->
   <div class="card">
-    <h2>{% if survey.survey_type == SurveyType.conjoint %}4{% else %}3{% endif %} · Results &amp; status</h2>
+    <h2>{% if two_step %}4{% else %}3{% endif %} · Results &amp; status</h2>
     <p>
       <a class="btn" href="/surveys/{{ survey.id }}/results">View analysis →</a>
       {% if survey.survey_type == SurveyType.conjoint %}

--- a/app/templates/survey/maxdiff.html
+++ b/app/templates/survey/maxdiff.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}{{ survey.name }}{% endblock %}
+{% block content %}
+  <h1>{{ survey.name }}</h1>
+  {% if survey.description %}<p class="muted">{{ survey.description }}</p>{% endif %}
+  <p class="muted">In each set, choose the <strong>one best</strong> and the
+    <strong>one worst</strong> item.</p>
+
+  {% if error %}<div class="error">{{ error }}</div>{% endif %}
+
+  <form method="post" action="/survey/{{ participant.token }}">
+    {% for s in sets %}
+      <div class="card">
+        <p class="muted" style="margin-top:0;">Set {{ s.position }} of {{ sets | length }}</p>
+        <table>
+          <thead>
+            <tr>
+              <th style="text-align:center; color:#2e7d32;">Best</th>
+              <th>Item</th>
+              <th style="text-align:center; color:#c62828;">Worst</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for it in s.options %}
+              <tr>
+                <td style="text-align:center;">
+                  <input type="radio" name="best_{{ s.id }}" value="{{ it.id }}" required
+                         {% if selected and selected.get(s.id) and selected[s.id].best == it.id %}checked{% endif %}>
+                </td>
+                <td>{{ it.text }}</td>
+                <td style="text-align:center;">
+                  <input type="radio" name="worst_{{ s.id }}" value="{{ it.id }}" required
+                         {% if selected and selected.get(s.id) and selected[s.id].worst == it.id %}checked{% endif %}>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% endfor %}
+    <p><button type="submit">Submit my answers</button></p>
+  </form>
+{% endblock %}

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -21,6 +21,8 @@ from app.models import (
     Item,
     ItemResponse,
     Level,
+    MaxDiffConfig,
+    MaxDiffResponse,
     Participant,
     ParticipantStatus,
     PricePerception,
@@ -31,7 +33,7 @@ from app.models import (
     SurveyStatus,
     SurveyType,
 )
-from app.services import generate_and_store_design
+from app.services import generate_and_store_design, generate_and_store_maxdiff
 
 # Attribute -> ordered levels for the demo study.
 ATTRIBUTES = {
@@ -202,6 +204,57 @@ def seed(num_participants: int = 60, seed: int = 7) -> None:
         db.commit()
         print(f"Seeded Ranking/Rating survey id={rt.id} with {num_participants} responses.")
         print(f"  Results: {settings.effective_base_url}/surveys/{rt.id}/results")
+
+        # --- MaxDiff demo ---------------------------------------------------
+        md_items = [
+            ("Lower price", 2.0),
+            ("Fast customer support", 1.6),
+            ("Better mobile app", 0.9),
+            ("More integrations", 0.4),
+            ("Advanced analytics", -0.2),
+            ("Single sign-on", -0.6),
+            ("Custom branding", -1.2),
+        ]
+        md = Survey(
+            name="Feature trade-offs (demo)",
+            description="Pick the best and worst feature in each set.",
+            survey_type=SurveyType.maxdiff,
+            currency="$",
+        )
+        db.add(md)
+        db.flush()
+        db.add(MaxDiffConfig(survey_id=md.id, items_per_set=4, num_sets=0))
+        util_by_item: dict[int, float] = {}
+        for pos, (text, util) in enumerate(md_items):
+            item = Item(survey_id=md.id, text=text, position=pos)
+            db.add(item)
+            db.flush()
+            util_by_item[item.id] = util
+        db.commit()
+        db.refresh(md)
+        generate_and_store_maxdiff(db, md, seed=seed)
+        db.refresh(md)
+
+        for i in range(num_participants):
+            participant = Participant(
+                survey_id=md.id,
+                email=f"md{i + 1}@example.com",
+                status=ParticipantStatus.completed,
+            )
+            db.add(participant)
+            db.flush()
+            for mset in md.maxdiff_sets:
+                ids = [si.item_id for si in mset.set_items]
+                noisy = {iid: util_by_item[iid] + rng.gauss(0, 0.8) for iid in ids}
+                db.add(MaxDiffResponse(
+                    participant_id=participant.id,
+                    set_id=mset.id,
+                    best_item_id=max(noisy, key=noisy.get),
+                    worst_item_id=min(noisy, key=noisy.get),
+                ))
+        db.commit()
+        print(f"Seeded MaxDiff survey id={md.id} with {num_participants} responses.")
+        print(f"  Results: {settings.effective_base_url}/surveys/{md.id}/results")
 
 
 if __name__ == "__main__":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -314,6 +314,62 @@ def test_rating_rank_flow():
     assert "Ranking" in results.text
 
 
+def test_maxdiff_full_flow():
+    init_db()
+    client.post("/surveys", data={"name": "Feature MaxDiff", "survey_type": "maxdiff"})
+    with SessionLocal() as db:
+        survey = db.scalar(select(Survey).where(Survey.name == "Feature MaxDiff"))
+        sid = survey.id
+        assert survey.survey_type == SurveyType.maxdiff
+        assert survey.maxdiff_config is not None
+
+    client.post(f"/surveys/{sid}/settings",
+                data={"items_per_set": "3", "num_sets": "5", "currency": "$"})
+    client.post(f"/surveys/{sid}/items",
+                data={"items": "Speed\nPrice\nSupport\nDesign\nAnalytics"})
+    client.post(f"/surveys/{sid}/generate")
+    with SessionLocal() as db:
+        survey = db.get(Survey, sid)
+        assert survey.status == SurveyStatus.active
+        assert len(survey.maxdiff_sets) == 5
+        assert all(len(s.set_items) == 3 for s in survey.maxdiff_sets)
+        # Capture each set's membership for building a valid submission.
+        sets = [(s.id, [si.item_id for si in s.set_items]) for s in survey.maxdiff_sets]
+
+    client.post(f"/surveys/{sid}/participants", data={"emails": "gus@example.com"})
+    with SessionLocal() as db:
+        token = db.scalar(
+            select(Participant).where(Participant.email == "gus@example.com")
+        ).token
+
+    page = client.get(f"/survey/{token}")
+    assert page.status_code == 200
+    assert "best" in page.text.lower() and "worst" in page.text.lower()
+
+    # Best == worst in a set is rejected.
+    bad_set_id, bad_members = sets[0]
+    bad = {f"best_{sid_}": str(mem[0]) for sid_, mem in sets}
+    bad.update({f"worst_{sid_}": str(mem[1]) for sid_, mem in sets})
+    bad[f"worst_{bad_set_id}"] = str(bad_members[0])  # same as best -> invalid
+    assert client.post(f"/survey/{token}", data=bad).status_code == 400
+
+    # Valid picks: first item best, second worst in each set.
+    good = {f"best_{sid_}": str(mem[0]) for sid_, mem in sets}
+    good.update({f"worst_{sid_}": str(mem[1]) for sid_, mem in sets})
+    ok = client.post(f"/survey/{token}", data=good)
+    assert ok.status_code == 200
+    assert "Thank you" in ok.text
+
+    with SessionLocal() as db:
+        p = db.scalar(select(Participant).where(Participant.token == token))
+        assert p.status == ParticipantStatus.completed
+        assert len(p.maxdiff_responses) == 5
+
+    results = client.get(f"/surveys/{sid}/results")
+    assert results.status_code == 200
+    assert "MaxDiff results" in results.text
+
+
 def test_market_simulator():
     sid = _create_survey_with_design()
     client.post(f"/surveys/{sid}/participants", data={"emails": "dave@example.com"})

--- a/tests/test_maxdiff.py
+++ b/tests/test_maxdiff.py
@@ -1,0 +1,60 @@
+"""Unit tests for the MaxDiff design generator and counting analysis."""
+
+import pytest
+
+from app.maxdiff import Observation, generate_design, suggested_num_sets, summarize
+
+
+def test_design_is_balanced_and_distinct():
+    n_items, k, num_sets = 7, 4, 12
+    sets = generate_design(n_items, k, num_sets, seed=1)
+
+    assert len(sets) == num_sets
+    for s in sets:
+        assert len(s) == k
+        assert len(set(s)) == k          # no repeats within a set
+        assert all(0 <= i < n_items for i in s)
+
+    # Appearances are balanced to within 1 across items.
+    counts = [0] * n_items
+    for s in sets:
+        for i in s:
+            counts[i] += 1
+    assert max(counts) - min(counts) <= 1
+
+
+def test_design_validates_inputs():
+    with pytest.raises(ValueError):
+        generate_design(3, 5, 6)        # items_per_set > n_items
+    with pytest.raises(ValueError):
+        generate_design(5, 1, 6)        # items_per_set < 2
+    with pytest.raises(ValueError):
+        generate_design(5, 3, 0)        # no sets
+
+
+def test_suggested_num_sets():
+    assert suggested_num_sets(8, 4) == 6   # ceil(3*8/4)
+    assert suggested_num_sets(0, 4) == 0
+
+
+def test_summary_scores_and_ordering():
+    items = [(1, "A"), (2, "B"), (3, "C")]
+    # A always best, C always worst across three sets that show all three.
+    obs = [
+        Observation(shown=[1, 2, 3], best=1, worst=3),
+        Observation(shown=[1, 2, 3], best=1, worst=3),
+        Observation(shown=[1, 2, 3], best=1, worst=2),
+    ]
+    res = summarize(items, obs, num_responses=3)
+
+    assert res.num_responses == 3
+    assert res.items[0].item_id == 1            # A best
+    assert res.items[-1].item_id == 3           # C worst
+    a = res.items[0]
+    assert a.appearances == 3 and a.best == 3 and a.worst == 0
+    assert abs(a.score - 1.0) < 1e-9            # (3 - 0) / 3
+
+
+def test_summary_requires_responses():
+    with pytest.raises(ValueError):
+        summarize([(1, "A")], [], num_responses=0)


### PR DESCRIPTION
## Summary

Second of the four new survey types (one PR per type). Adds a **MaxDiff** (best–worst scaling) survey: respondents see a series of small, balanced sets of items and pick the **best** and **worst** in each.

- **Design**: a count-balanced generator produces sets where each item appears about equally and never repeats within a set. Items-per-set and number-of-sets are configurable (number-of-sets `0` = auto, sized so each item appears ~3×).
- **Analysis** (counting model): for each item, **best-minus-worst score** = `(best − worst) / appearances` (range −1…+1), plus best/worst rates and appearance counts, sorted best-first.

## Deploy safety (no migrations framework)

Additive again — `init_db()`'s `create_all` only creates missing **tables**, never alters existing ones:

- New tables only: `maxdiff_configs`, `maxdiff_sets`, `maxdiff_set_items`, `maxdiff_responses`. **No new columns on `surveys`.** Items are shared with the Ranking/Rating type (`items` table).

## What's included

- **maxdiff.py**: design generator + counting summary (pure, unit-tested).
- **models**: `SurveyType.maxdiff` and the four new tables + relationships.
- **admin**: create flow, design settings (items-per-set / num-sets), design generation, build UI, and a results page with a centered best-worst score bar. The `/items` routes are reused for MaxDiff; `admin/survey.html` now numbers cards 1–4 for design-based types (conjoint, MaxDiff) and 1–3 otherwise.
- **survey (respondent)**: best/worst radio grid per set, with server-side validation (best ≠ worst; picks must be within the set).
- **seed_demo**: adds a MaxDiff demo; **README** documents the type.

## Testing

- `pytest` → **41 passing** (added design-balance + summary unit tests and an end-to-end flow: build → generate → respond → results).
- Live smoke test through `uvicorn`: seeded a MaxDiff study, then rendered the admin build page, the respondent grid, and the results page — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMQ2LNzm9UvwVaBwrDXL4U)_